### PR TITLE
feat: redesign UI to not look like shit

### DIFF
--- a/network-topology-mapper/backend/app/routers/topology.py
+++ b/network-topology-mapper/backend/app/routers/topology.py
@@ -66,6 +66,15 @@ def get_topology_stats():
     }
 
 
+@router.post("/topology/import")
+def import_topology(payload: dict):
+    devices = payload.get("devices", [])
+    connections = payload.get("connections", [])
+    dependencies = payload.get("dependencies", [])
+    result = graph_builder.bulk_upsert(devices, connections, dependencies)
+    return result
+
+
 @router.post("/topology/clear")
 def clear_topology():
     topology_db.clear_all()

--- a/network-topology-mapper/frontend/index.html
+++ b/network-topology-mapper/frontend/index.html
@@ -6,10 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Doto:wght@400;700&family=Space+Grotesk:wght@300;400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" />
     <title>Network Topology Scanner</title>
   </head>
-  <body class="bg-bg-primary text-text-primary">
+  <body class="bg-nd-black text-nd-text-primary">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/network-topology-mapper/frontend/src/App.tsx
+++ b/network-topology-mapper/frontend/src/App.tsx
@@ -11,7 +11,7 @@ import ResilienceReport from './components/panels/ResilienceReport';
 import RiskHeatmap from './components/dashboard/RiskHeatmap';
 import TimelineView from './components/dashboard/TimelineView';
 import DependencyMatrix from './components/dashboard/DependencyMatrix';
-import { Settings } from 'lucide-react';
+import { useFilterStore } from './stores/filterStore';
 
 function TopologyView() {
   const { rightPanelContent, selectedDeviceId } = useTopologyStore();
@@ -20,7 +20,7 @@ function TopologyView() {
     <div className="flex flex-col h-full">
       <MetricsBar />
       <div className="flex flex-1 overflow-hidden">
-        <div className="flex-1 relative">
+        <div className="flex-1 min-w-0 relative">
           <NetworkCanvas />
         </div>
         {rightPanelContent === 'device' && selectedDeviceId && <DeviceInspector />}
@@ -32,49 +32,53 @@ function TopologyView() {
 }
 
 function DashboardView() {
-  const { stats, devices, spofs } = useTopologyStore();
+  const { stats, spofs } = useTopologyStore();
 
-  if (!stats) return <div className="p-6 text-text-muted">Loading...</div>;
+  if (!stats) return <div className="p-6 font-mono text-caption text-nd-text-disabled">[LOADING...]</div>;
 
   const typeEntries = Object.entries(stats.type_counts).sort((a, b) => b[1] - a[1]);
 
   return (
     <div className="h-full overflow-y-auto p-6">
       <div className="max-w-5xl mx-auto space-y-6">
-        <h1 className="text-xl font-bold text-text-primary">Dashboard</h1>
+        <h1 className="font-display text-display-md font-bold text-black">Dashboard</h1>
 
         <MetricsBar />
 
         <div className="grid grid-cols-2 gap-6">
           {/* Device types breakdown */}
-          <div className="bg-bg-secondary rounded-xl p-5 border border-bg-tertiary">
-            <h3 className="text-sm font-semibold text-text-primary mb-4">Device Types</h3>
+          <div className="bg-nd-surface rounded-nd-card p-5 border border-nd-border">
+            <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary mb-4">Device Types</div>
             <div className="space-y-3">
-              {typeEntries.map(([type, count]) => (
-                <div key={type} className="flex items-center gap-3">
-                  <span className="text-xs text-text-secondary capitalize w-24">{type}</span>
-                  <div className="flex-1 h-2 bg-bg-tertiary rounded-full overflow-hidden">
-                    <div
-                      className="h-full rounded-full"
-                      style={{
-                        width: `${(count / stats.total_devices) * 100}%`,
-                        backgroundColor: `var(--node-${type}, #6B7280)`,
-                      }}
-                    />
+              {typeEntries.map(([type, count]) => {
+                const segments = 10;
+                const filled = Math.round((count / stats.total_devices) * segments);
+                return (
+                  <div key={type} className="flex items-center gap-3">
+                    <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled w-24">{type}</span>
+                    <div className="flex-1 h-2 flex gap-[2px]">
+                      {Array.from({ length: segments }).map((_, i) => (
+                        <div
+                          key={i}
+                          className="flex-1 h-full"
+                          style={{ backgroundColor: i < filled ? '#1A1A1A' : '#E8E8E8' }}
+                        />
+                      ))}
+                    </div>
+                    <span className="font-mono text-caption text-nd-text-secondary w-8 text-right">{count}</span>
                   </div>
-                  <span className="text-xs text-text-muted w-8 text-right">{count}</span>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </div>
 
           {/* Status breakdown */}
-          <div className="bg-bg-secondary rounded-xl p-5 border border-bg-tertiary">
-            <h3 className="text-sm font-semibold text-text-primary mb-4">Device Status</h3>
+          <div className="bg-nd-surface rounded-nd-card p-5 border border-nd-border">
+            <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary mb-4">Status</div>
             <div className="flex gap-6 items-end h-32">
-              <StatusBar label="Online" count={stats.online} total={stats.total_devices} color="#10B981" />
-              <StatusBar label="Offline" count={stats.offline} total={stats.total_devices} color="#EF4444" />
-              <StatusBar label="Degraded" count={stats.degraded} total={stats.total_devices} color="#F59E0B" />
+              <StatusBar label="Online" count={stats.online} total={stats.total_devices} color="#4A9E5C" />
+              <StatusBar label="Offline" count={stats.offline} total={stats.total_devices} color="#D71921" />
+              <StatusBar label="Degraded" count={stats.degraded} total={stats.total_devices} color="#D4A843" />
             </div>
           </div>
         </div>
@@ -89,87 +93,67 @@ function StatusBar({ label, count, total, color }: { label: string; count: numbe
   const pct = total > 0 ? (count / total) * 100 : 0;
   return (
     <div className="flex-1 flex flex-col items-center gap-2">
-      <span className="text-lg font-bold" style={{ color }}>{count}</span>
-      <div className="w-full bg-bg-tertiary rounded-full overflow-hidden" style={{ height: `${Math.max(pct, 5)}%`, minHeight: 4 }}>
-        <div className="w-full h-full rounded-full" style={{ backgroundColor: color }} />
+      <span className="font-mono text-heading font-bold" style={{ color }}>{count}</span>
+      <div className="w-full overflow-hidden" style={{ height: `${Math.max(pct, 5)}%`, minHeight: 4 }}>
+        <div className="w-full h-full" style={{ backgroundColor: color }} />
       </div>
-      <span className="text-[10px] text-text-muted">{label}</span>
+      <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">{label}</span>
     </div>
   );
 }
 
 function SettingsView() {
+  const { showLabels, setShowLabels, showRiskHalos, setShowRiskHalos } = useFilterStore();
+
   return (
     <div className="h-full overflow-y-auto p-6">
       <div className="max-w-2xl mx-auto space-y-6">
-        <h1 className="text-xl font-bold text-text-primary">Settings</h1>
+        <h1 className="font-display text-display-md font-bold text-black">Settings</h1>
 
-        <div className="bg-bg-secondary rounded-xl p-5 border border-bg-tertiary space-y-4">
-          <h3 className="text-sm font-semibold text-text-primary">Scan Configuration</h3>
+        <div className="bg-nd-surface rounded-nd-card p-5 border border-nd-border space-y-4">
+          <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Scan Configuration</div>
 
           <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="text-xs text-text-primary">Full Scan Interval</div>
-                <div className="text-[10px] text-text-muted">How often to run a complete network scan</div>
-              </div>
-              <select className="bg-bg-tertiary border border-bg-tertiary rounded-lg px-3 py-1.5 text-xs text-text-primary outline-none">
+            <SettingRow label="Full Scan Interval" description="How often to run a complete network scan">
+              <select className="bg-nd-surface-raised border border-nd-border-visible rounded-nd-compact px-3 py-1.5 font-mono text-caption text-nd-text-primary outline-none focus:border-nd-text-disabled transition-colors">
                 <option value="3600">Every 1 hour</option>
                 <option value="7200">Every 2 hours</option>
-                <option value="21600" selected>Every 6 hours</option>
+                <option value="21600">Every 6 hours</option>
                 <option value="86400">Every 24 hours</option>
               </select>
-            </div>
+            </SettingRow>
 
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="text-xs text-text-primary">SNMP Poll Interval</div>
-                <div className="text-[10px] text-text-muted">Frequency of SNMP device queries</div>
-              </div>
-              <select className="bg-bg-tertiary border border-bg-tertiary rounded-lg px-3 py-1.5 text-xs text-text-primary outline-none">
+            <SettingRow label="SNMP Poll Interval" description="Frequency of SNMP device queries">
+              <select className="bg-nd-surface-raised border border-nd-border-visible rounded-nd-compact px-3 py-1.5 font-mono text-caption text-nd-text-primary outline-none focus:border-nd-text-disabled transition-colors">
                 <option value="900">Every 15 min</option>
-                <option value="1800" selected>Every 30 min</option>
+                <option value="1800">Every 30 min</option>
                 <option value="3600">Every 1 hour</option>
               </select>
-            </div>
+            </SettingRow>
 
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="text-xs text-text-primary">Agent Mode</div>
-                <div className="text-[10px] text-text-muted">How the system responds to findings</div>
-              </div>
-              <select className="bg-bg-tertiary border border-bg-tertiary rounded-lg px-3 py-1.5 text-xs text-text-primary outline-none">
-                <option value="alert" selected>Alert Only</option>
+            <SettingRow label="Agent Mode" description="How the system responds to findings">
+              <select className="bg-nd-surface-raised border border-nd-border-visible rounded-nd-compact px-3 py-1.5 font-mono text-caption text-nd-text-primary outline-none focus:border-nd-text-disabled transition-colors">
+                <option value="alert">Alert Only</option>
                 <option value="interactive">Interactive</option>
                 <option value="autonomous">Autonomous</option>
               </select>
-            </div>
+            </SettingRow>
           </div>
         </div>
 
-        <div className="bg-bg-secondary rounded-xl p-5 border border-bg-tertiary space-y-4">
-          <h3 className="text-sm font-semibold text-text-primary">Display</h3>
+        <div className="bg-nd-surface rounded-nd-card p-5 border border-nd-border space-y-4">
+          <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Display</div>
           <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <span className="text-xs text-text-primary">Show node labels</span>
-              <input type="checkbox" defaultChecked className="accent-node-switch" />
-            </div>
-            <div className="flex items-center justify-between">
-              <span className="text-xs text-text-primary">Show risk halos</span>
-              <input type="checkbox" defaultChecked className="accent-node-switch" />
-            </div>
-            <div className="flex items-center justify-between">
-              <span className="text-xs text-text-primary">Animation enabled</span>
-              <input type="checkbox" defaultChecked className="accent-node-switch" />
-            </div>
+            <ToggleRow label="Show node labels" checked={showLabels} onChange={setShowLabels} />
+            <ToggleRow label="Show risk indicators" checked={showRiskHalos} onChange={setShowRiskHalos} />
           </div>
         </div>
 
-        <div className="bg-bg-secondary rounded-xl p-5 border border-bg-tertiary">
-          <h3 className="text-sm font-semibold text-text-primary mb-2">About</h3>
-          <div className="text-xs text-text-secondary space-y-1">
-            <p>Network Topology Mapper v1.0.0</p>
-            <p>Real-time network discovery, visualization, and resilience analysis.</p>
+        <div className="bg-nd-surface rounded-nd-card p-5 border border-nd-border">
+          <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary mb-2">About</div>
+          <div className="space-y-1">
+            <p className="font-mono text-caption text-nd-text-primary">Network Topology Mapper v1.0.0</p>
+            <p className="text-caption text-nd-text-secondary">Real-time network discovery, visualization, and resilience analysis.</p>
           </div>
         </div>
       </div>
@@ -177,9 +161,33 @@ function SettingsView() {
   );
 }
 
-function SimulateView() {
-  const { setRightPanelContent } = useTopologyStore();
+function SettingRow({ label, description, children }: { label: string; description: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between py-1 border-b border-nd-border last:border-0">
+      <div>
+        <div className="font-sans text-body-sm text-nd-text-primary">{label}</div>
+        <div className="font-mono text-label text-nd-text-disabled">{description}</div>
+      </div>
+      {children}
+    </div>
+  );
+}
 
+function ToggleRow({ label, checked, onChange }: { label: string; checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <div className="flex items-center justify-between py-1 border-b border-nd-border last:border-0">
+      <span className="font-sans text-body-sm text-nd-text-primary">{label}</span>
+      <button
+        onClick={() => onChange(!checked)}
+        className={`w-10 h-5 rounded-nd-pill relative transition-colors border ${checked ? 'bg-black border-black' : 'bg-nd-surface-raised border-nd-border-visible'}`}
+      >
+        <div className={`absolute top-0.5 w-4 h-4 rounded-full transition-all ${checked ? 'left-5 bg-white' : 'left-0.5 bg-nd-text-secondary'}`} />
+      </button>
+    </div>
+  );
+}
+
+function SimulateView() {
   return (
     <div className="flex h-full">
       <div className="flex-1 relative">

--- a/network-topology-mapper/frontend/src/components/dashboard/DependencyMatrix.tsx
+++ b/network-topology-mapper/frontend/src/components/dashboard/DependencyMatrix.tsx
@@ -22,8 +22,8 @@ export default function DependencyMatrix() {
 
   if (servers.length === 0) {
     return (
-      <div className="h-full flex items-center justify-center text-text-muted text-sm">
-        No dependency data available
+      <div className="h-full flex items-center justify-center">
+        <span className="font-mono text-caption text-nd-text-disabled">[NO DEPENDENCY DATA]</span>
       </div>
     );
   }
@@ -31,20 +31,22 @@ export default function DependencyMatrix() {
   return (
     <div className="h-full overflow-auto p-6">
       <div className="max-w-6xl mx-auto">
-        <h1 className="text-xl font-bold text-text-primary mb-6">Service Dependency Matrix</h1>
+        <h1 className="font-display text-display-md font-bold text-black mb-6">Dependencies</h1>
 
         <div className="overflow-x-auto">
           <table className="border-collapse">
             <thead>
               <tr>
-                <th className="p-2 text-[10px] text-text-muted text-left sticky left-0 bg-bg-primary z-10">
-                  Depends on \u2192
+                <th className="p-2 font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled text-left sticky left-0 bg-nd-black z-10">
+                  Depends on {'\u2192'}
                 </th>
                 {servers.slice(0, 20).map((s) => (
-                  <th key={s.id} className="p-2 text-[10px] text-text-muted">
+                  <th key={s.id} className="p-2">
                     <div className="flex flex-col items-center gap-1 min-w-[60px]">
                       <DeviceIcon type={s.device_type as DeviceType} size={12} />
-                      <span className="truncate max-w-[60px]">{s.hostname.split('-').pop() || s.ip.split('.').pop()}</span>
+                      <span className="font-mono text-label text-nd-text-disabled truncate max-w-[60px]">
+                        {s.hostname.split('-').pop() || s.ip.split('.').pop()}
+                      </span>
                     </div>
                   </th>
                 ))}
@@ -53,7 +55,7 @@ export default function DependencyMatrix() {
             <tbody>
               {servers.slice(0, 20).map((row) => (
                 <tr key={row.id}>
-                  <td className="p-2 text-xs text-text-secondary sticky left-0 bg-bg-primary z-10 border-r border-bg-tertiary">
+                  <td className="p-2 font-mono text-caption text-nd-text-secondary sticky left-0 bg-nd-black z-10 border-r border-nd-border">
                     <div className="flex items-center gap-2">
                       <DeviceIcon type={row.device_type as DeviceType} size={12} />
                       <span className="truncate max-w-[100px]">{row.hostname || row.ip}</span>
@@ -66,11 +68,11 @@ export default function DependencyMatrix() {
                     return (
                       <td key={col.id} className="p-2 text-center">
                         {isSelf ? (
-                          <div className="w-4 h-4 rounded bg-bg-tertiary/50 mx-auto" />
+                          <div className="w-4 h-4 bg-nd-border mx-auto" />
                         ) : hasDep ? (
-                          <div className="w-4 h-4 rounded bg-node-switch/60 mx-auto" title={`${row.hostname} depends on ${col.hostname}`} />
+                          <div className="w-4 h-4 bg-black mx-auto" title={`${row.hostname} depends on ${col.hostname}`} />
                         ) : (
-                          <div className="w-4 h-4 rounded bg-bg-tertiary/20 mx-auto" />
+                          <div className="w-4 h-4 bg-nd-surface-raised mx-auto" />
                         )}
                       </td>
                     );
@@ -81,14 +83,14 @@ export default function DependencyMatrix() {
           </table>
         </div>
 
-        <div className="flex items-center gap-4 mt-4 text-xs text-text-muted">
+        <div className="flex items-center gap-4 mt-4">
           <div className="flex items-center gap-1.5">
-            <div className="w-3 h-3 rounded bg-node-switch/60" />
-            <span>Dependency exists</span>
+            <div className="w-3 h-3 bg-black" />
+            <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">Dependency</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <div className="w-3 h-3 rounded bg-bg-tertiary/20" />
-            <span>No dependency</span>
+            <div className="w-3 h-3 bg-nd-surface-raised" />
+            <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">None</span>
           </div>
         </div>
       </div>

--- a/network-topology-mapper/frontend/src/components/dashboard/MetricsBar.tsx
+++ b/network-topology-mapper/frontend/src/components/dashboard/MetricsBar.tsx
@@ -1,6 +1,4 @@
-import { Radio, Link2, AlertTriangle, Shield } from 'lucide-react';
 import { useTopologyStore } from '../../stores/topologyStore';
-import { getRiskColor } from '../../lib/graph-utils';
 
 export default function MetricsBar() {
   const { stats, spofs } = useTopologyStore();
@@ -8,58 +6,58 @@ export default function MetricsBar() {
   if (!stats) return null;
 
   const riskScore = stats.risk_score;
-  const riskColor = getRiskColor(riskScore / 10);
+  const riskColor = riskScore < 3 ? '#4A9E5C' : riskScore < 6 ? '#D4A843' : '#D71921';
+  const spofColor = stats.spof_count > 0 ? '#D71921' : '#4A9E5C';
 
   const cards = [
     {
-      icon: Radio,
       value: stats.total_devices,
       label: 'Devices',
       sub: `${stats.online} online`,
-      color: '#6366F1',
+      color: '#1A1A1A',
     },
     {
-      icon: Link2,
       value: stats.total_connections,
       label: 'Links',
       sub: `${stats.connection_uptime_pct}% uptime`,
-      color: '#34D399',
+      color: '#1A1A1A',
     },
     {
-      icon: AlertTriangle,
       value: riskScore.toFixed(1),
       label: 'Risk Score',
       sub: '/ 10',
       color: riskColor,
     },
     {
-      icon: Shield,
       value: stats.spof_count,
       label: 'SPOFs',
       sub: `${spofs.filter((s) => s.impact > 10).length} critical`,
-      color: stats.spof_count > 0 ? '#F87171' : '#34D399',
-      alert: stats.spof_count > 0,
+      color: spofColor,
     },
   ];
 
   return (
-    <div className="flex gap-3 px-4 py-3 border-b border-border flex-shrink-0">
+    <div className="flex gap-3 px-4 py-3 border-b border-nd-border flex-shrink-0">
       {cards.map((card) => (
         <div
           key={card.label}
-          className={`flex-1 flex items-center gap-3 rounded-lg px-3.5 py-2.5 border transition-colors ${
-            card.alert
-              ? 'border-status-offline/20 bg-status-offline/5'
-              : 'border-border bg-bg-secondary'
-          }`}
+          className="flex-1 flex items-center gap-3 rounded-nd-compact px-4 py-3 border border-nd-border bg-nd-surface"
         >
-          <card.icon size={16} style={{ color: card.color }} className="flex-shrink-0 opacity-70" />
           <div>
             <div className="flex items-baseline gap-1.5">
-              <span className="text-lg font-semibold text-text-primary leading-none">{card.value}</span>
-              <span className="text-[11px] text-text-muted">{card.sub}</span>
+              <span
+                className="font-mono text-[24px] font-bold leading-none"
+                style={{ color: card.color }}
+              >
+                {card.value}
+              </span>
+              <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">
+                {card.sub}
+              </span>
             </div>
-            <div className="text-[11px] text-text-muted mt-0.5">{card.label}</div>
+            <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary mt-1">
+              {card.label}
+            </div>
           </div>
         </div>
       ))}

--- a/network-topology-mapper/frontend/src/components/dashboard/RiskHeatmap.tsx
+++ b/network-topology-mapper/frontend/src/components/dashboard/RiskHeatmap.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { useTopologyStore } from '../../stores/topologyStore';
 import { getRiskColor } from '../../lib/graph-utils';
-import { useFilterStore } from '../../stores/filterStore';
 
 interface VlanGroup {
   vlanId: number;
@@ -21,7 +20,6 @@ const VLAN_NAMES: Record<number, string> = {
 
 export default function RiskHeatmap() {
   const { devices, spofs } = useTopologyStore();
-  const { setActiveLayer } = useFilterStore();
 
   const vlanGroups = useMemo(() => {
     const groups: Record<number, VlanGroup> = {};
@@ -46,7 +44,6 @@ export default function RiskHeatmap() {
       });
     });
 
-    // Calculate averages
     Object.values(groups).forEach((g) => {
       g.avgRisk = g.devices > 0 ? g.avgRisk / g.devices : 0;
     });
@@ -54,63 +51,51 @@ export default function RiskHeatmap() {
     return Object.values(groups).sort((a, b) => b.avgRisk - a.avgRisk);
   }, [devices, spofs]);
 
-  const maxDevices = Math.max(...vlanGroups.map((g) => g.devices), 1);
+  const segments = 10;
 
   return (
     <div className="h-full overflow-y-auto p-6">
       <div className="max-w-4xl mx-auto">
-        <h1 className="text-xl font-bold text-text-primary mb-6">Risk Heatmap</h1>
+        <h1 className="font-display text-display-md font-bold text-black mb-6">Risk Heatmap</h1>
 
         <div className="grid grid-cols-2 gap-4">
           {vlanGroups.map((group) => {
             const color = getRiskColor(group.avgRisk);
-            const sizeRatio = group.devices / maxDevices;
-            const minHeight = 120;
-            const height = minHeight + sizeRatio * 100;
+            const filled = Math.round(group.avgRisk * segments);
 
             return (
               <div
                 key={group.vlanId}
-                className="rounded-xl border border-bg-tertiary cursor-pointer hover:border-text-muted/30 transition-all relative overflow-hidden"
-                style={{
-                  minHeight: height,
-                  backgroundColor: `${color}10`,
-                  borderColor: `${color}30`,
-                }}
+                className="bg-nd-surface rounded-nd-card border border-nd-border p-5 hover:border-nd-border-visible transition-colors"
               >
-                <div className="absolute inset-0 opacity-5" style={{ backgroundColor: color }} />
-                <div className="relative p-5">
-                  <div className="flex items-center justify-between mb-3">
-                    <h3 className="text-sm font-semibold text-text-primary">
-                      VLAN {group.vlanId} - {group.name}
+                <div className="flex items-center justify-between mb-4">
+                  <div>
+                    <h3 className="font-sans text-body-sm font-medium text-nd-text-display">
+                      {group.name}
                     </h3>
+                    <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">VLAN {group.vlanId}</span>
                   </div>
+                  <span className="font-mono text-heading font-bold" style={{ color }}>
+                    {group.avgRisk.toFixed(2)}
+                  </span>
+                </div>
 
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs text-text-muted">Risk</span>
-                      <span className="text-lg font-bold font-mono" style={{ color }}>
-                        {group.avgRisk.toFixed(2)}
-                      </span>
-                    </div>
+                {/* Segmented bar */}
+                <div className="h-2 flex gap-[2px] mb-3">
+                  {Array.from({ length: segments }).map((_, i) => (
+                    <div
+                      key={i}
+                      className="flex-1 h-full"
+                      style={{ backgroundColor: i < filled ? color : '#E8E8E8' }}
+                    />
+                  ))}
+                </div>
 
-                    <div className="h-1.5 bg-bg-tertiary rounded-full overflow-hidden">
-                      <div
-                        className="h-full rounded-full"
-                        style={{
-                          width: `${group.avgRisk * 100}%`,
-                          backgroundColor: color,
-                        }}
-                      />
-                    </div>
-
-                    <div className="flex justify-between text-xs">
-                      <span className="text-text-secondary">{group.devices} devices</span>
-                      <span className={group.spofCount > 0 ? 'text-risk-critical font-medium' : 'text-text-muted'}>
-                        {group.spofCount} SPOF{group.spofCount !== 1 ? 's' : ''}
-                      </span>
-                    </div>
-                  </div>
+                <div className="flex justify-between">
+                  <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">{group.devices} devices</span>
+                  <span className={`font-mono text-label uppercase tracking-[0.08em] ${group.spofCount > 0 ? 'text-nd-accent font-bold' : 'text-nd-text-disabled'}`}>
+                    {group.spofCount} SPOF{group.spofCount !== 1 ? 's' : ''}
+                  </span>
                 </div>
               </div>
             );
@@ -118,7 +103,7 @@ export default function RiskHeatmap() {
         </div>
 
         {vlanGroups.length === 0 && (
-          <div className="text-center text-text-muted py-12">No VLAN data available</div>
+          <div className="text-center py-12 font-mono text-caption text-nd-text-disabled">[NO VLAN DATA AVAILABLE]</div>
         )}
       </div>
     </div>

--- a/network-topology-mapper/frontend/src/components/dashboard/TimelineView.tsx
+++ b/network-topology-mapper/frontend/src/components/dashboard/TimelineView.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useState } from 'react';
-import { Clock, Radio, Link2, AlertTriangle, FileText, Eye } from 'lucide-react';
+import { useState } from 'react';
+import { AlertTriangle } from 'lucide-react';
 import { useAlerts } from '../../hooks/useAlerts';
-import { fetchChangelog } from '../../lib/api';
 import { formatTimeAgo, getSeverityColor } from '../../lib/graph-utils';
-import type { Alert } from '../../types/topology';
 
 interface TimelineEntry {
   id: string;
@@ -35,16 +33,17 @@ export default function TimelineView() {
     <div className="h-full overflow-y-auto p-6">
       <div className="max-w-2xl mx-auto">
         <div className="flex items-center justify-between mb-6">
-          <h1 className="text-xl font-bold text-text-primary">Topology Timeline</h1>
-          <div className="flex rounded-lg bg-bg-secondary border border-bg-tertiary overflow-hidden">
+          <h1 className="font-display text-display-md font-bold text-black">Timeline</h1>
+          {/* Segmented control for time range */}
+          <div className="flex border border-nd-border-visible rounded-nd-pill overflow-hidden">
             {(['24h', '7d', '30d'] as const).map((range) => (
               <button
                 key={range}
                 onClick={() => setTimeRange(range)}
-                className={`px-3 py-1 text-xs transition-colors ${
+                className={`px-3 py-1 font-mono text-label uppercase tracking-[0.08em] transition-colors ${
                   timeRange === range
-                    ? 'bg-node-switch/20 text-node-switch'
-                    : 'text-text-muted hover:text-text-primary'
+                    ? 'bg-black text-white'
+                    : 'text-nd-text-secondary hover:text-nd-text-primary'
                 }`}
               >
                 {range}
@@ -54,47 +53,45 @@ export default function TimelineView() {
         </div>
 
         {entries.length === 0 && (
-          <div className="text-center text-text-muted py-12">
-            <Clock size={48} className="mx-auto mb-3 text-text-muted/30" />
-            <p className="text-sm">No timeline events</p>
+          <div className="text-center py-12">
+            <div className="font-mono text-caption text-nd-text-disabled">[NO TIMELINE EVENTS]</div>
           </div>
         )}
 
         <div className="relative">
           {/* Vertical line */}
-          <div className="absolute left-4 top-0 bottom-0 w-px bg-bg-tertiary" />
+          <div className="absolute left-4 top-0 bottom-0 w-px bg-nd-border" />
 
           <div className="space-y-0">
             {entries.map((entry) => {
-              const Icon = entry.icon;
-              const dotColor = entry.severity ? getSeverityColor(entry.severity) : '#6B7280';
+              const dotColor = entry.severity ? getSeverityColor(entry.severity) : '#999999';
 
               return (
                 <div key={entry.id} className="relative flex gap-4 py-3 pl-0">
                   {/* Dot */}
                   <div
-                    className="w-9 h-9 rounded-full flex items-center justify-center z-10 flex-shrink-0 bg-bg-primary border-2"
+                    className="w-9 h-9 rounded-full flex items-center justify-center z-10 flex-shrink-0 bg-nd-black border-2"
                     style={{ borderColor: dotColor }}
                   >
-                    <Icon size={14} style={{ color: dotColor }} />
+                    <div className="w-2 h-2 rounded-full" style={{ backgroundColor: dotColor }} />
                   </div>
 
                   {/* Content */}
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-0.5">
-                      <span className="text-[10px] text-text-muted">{formatTimeAgo(entry.timestamp)}</span>
+                      <span className="font-mono text-label text-nd-text-disabled">{formatTimeAgo(entry.timestamp)}</span>
                       {entry.severity && (
                         <span
-                          className="text-[10px] font-bold uppercase"
+                          className="font-mono text-label uppercase tracking-[0.08em] font-bold"
                           style={{ color: getSeverityColor(entry.severity) }}
                         >
                           {entry.severity}
                         </span>
                       )}
                     </div>
-                    <h4 className="text-xs font-medium text-text-primary">{entry.title}</h4>
+                    <h4 className="font-sans text-body-sm font-medium text-nd-text-primary">{entry.title}</h4>
                     {entry.description && (
-                      <p className="text-[11px] text-text-secondary mt-0.5">{entry.description}</p>
+                      <p className="text-caption text-nd-text-secondary mt-0.5">{entry.description}</p>
                     )}
                   </div>
                 </div>

--- a/network-topology-mapper/frontend/src/components/graph/EdgeLabel.tsx
+++ b/network-topology-mapper/frontend/src/components/graph/EdgeLabel.tsx
@@ -1,28 +1,21 @@
 import type { Connection } from '../../types/topology';
-import { CONNECTION_TYPE_COLORS } from '../../lib/graph-utils';
 
 interface Props {
   connection: Connection;
 }
 
 export default function EdgeLabel({ connection }: Props) {
-  const color = CONNECTION_TYPE_COLORS[connection.connection_type] || '#475569';
-
   return (
-    <div className="inline-flex items-center gap-2 px-2 py-1 rounded bg-bg-secondary border border-bg-tertiary text-xs">
-      <span
-        className="w-2 h-2 rounded-full"
-        style={{ backgroundColor: color }}
-      />
-      <span className="text-text-secondary capitalize">{connection.connection_type}</span>
+    <div className="inline-flex items-center gap-2 px-2 py-1 rounded-nd-technical bg-nd-surface border border-nd-border-visible font-mono text-caption">
+      <span className="text-nd-text-primary uppercase">{connection.connection_type}</span>
       {connection.bandwidth && (
-        <span className="text-text-muted">{connection.bandwidth}</span>
+        <span className="text-nd-text-disabled">{connection.bandwidth}</span>
       )}
       {connection.latency_ms > 0 && (
-        <span className="text-text-muted">{connection.latency_ms}ms</span>
+        <span className="text-nd-text-disabled">{connection.latency_ms}ms</span>
       )}
       {connection.status === 'flapping' && (
-        <span className="text-risk-critical font-medium">FLAPPING</span>
+        <span className="text-nd-accent font-bold uppercase">Flapping</span>
       )}
     </div>
   );

--- a/network-topology-mapper/frontend/src/components/graph/GraphControls.tsx
+++ b/network-topology-mapper/frontend/src/components/graph/GraphControls.tsx
@@ -14,11 +14,6 @@ const deviceTypes: DeviceType[] = [
   'router', 'switch', 'server', 'firewall', 'ap', 'workstation', 'printer', 'iot',
 ];
 
-const typeColors: Record<string, string> = {
-  router: '#818CF8', switch: '#60A5FA', server: '#34D399', firewall: '#FBBF24',
-  ap: '#A78BFA', workstation: '#94A3B8', printer: '#FB923C', iot: '#F472B6',
-};
-
 interface Props {
   onFit: () => void;
   onZoomIn: () => void;
@@ -34,68 +29,70 @@ export default function GraphControls({ onFit, onZoomIn, onZoomOut }: Props) {
   const [showLayoutMenu, setShowLayoutMenu] = useState(false);
   const [showFilterMenu, setShowFilterMenu] = useState(false);
 
-  const btnBase = "w-8 h-8 rounded-md flex items-center justify-center transition-colors";
-  const btnOff = `${btnBase} text-text-muted hover:text-text-secondary hover:bg-bg-tertiary`;
-  const btnOn = `${btnBase} text-accent-light bg-accent/10`;
+  const btnBase = "w-8 h-8 rounded-nd-technical flex items-center justify-center transition-colors";
+  const btnOff = `${btnBase} text-nd-text-disabled hover:text-nd-text-primary hover:bg-nd-surface-raised`;
+  const btnOn = `${btnBase} text-nd-text-display bg-nd-surface-raised`;
 
   return (
     <div className="absolute bottom-4 right-4 flex items-end gap-2 z-10">
+      {/* Layout dropdown */}
       {showLayoutMenu && (
-        <div className="bg-bg-secondary border border-border rounded-lg py-1 shadow-lg min-w-[150px] animate-fade-in">
-          <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-text-muted">Layout</div>
+        <div className="bg-white border border-nd-border-visible rounded-nd-compact py-1 min-w-[150px] animate-fade-in z-30" style={{ boxShadow: '0 4px 12px rgba(0,0,0,0.08)' }}>
+          <div className="px-3 py-1 font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">Layout</div>
           {layouts.map((l) => (
             <button
               key={l.value}
               onClick={() => { setActiveLayout(l.value); setShowLayoutMenu(false); }}
-              className={`w-full text-left px-3 py-1.5 text-[13px] transition-colors flex items-center justify-between ${
-                activeLayout === l.value ? 'text-accent-light bg-accent/5' : 'text-text-secondary hover:text-text-primary hover:bg-bg-tertiary'
+              className={`w-full text-left px-3 py-1.5 text-body-sm font-sans transition-colors flex items-center justify-between ${
+                activeLayout === l.value ? 'text-nd-text-display bg-nd-surface-raised' : 'text-nd-text-secondary hover:text-nd-text-primary hover:bg-nd-surface-raised'
               }`}
             >
               {l.label}
-              {activeLayout === l.value && <div className="w-1.5 h-1.5 rounded-full bg-accent" />}
+              {activeLayout === l.value && <div className="w-1.5 h-1.5 rounded-full bg-nd-accent" />}
             </button>
           ))}
         </div>
       )}
 
+      {/* Filter dropdown */}
       {showFilterMenu && (
-        <div className="bg-bg-secondary border border-border rounded-lg py-2 px-1.5 shadow-lg min-w-[170px] animate-fade-in">
-          <div className="px-2 pb-1.5 text-[10px] font-medium uppercase tracking-wider text-text-muted flex justify-between">
+        <div className="bg-white border border-nd-border-visible rounded-nd-compact py-2 px-1.5 min-w-[170px] animate-fade-in z-30" style={{ boxShadow: '0 4px 12px rgba(0,0,0,0.08)' }}>
+          <div className="px-2 pb-1.5 font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled flex justify-between">
             <span>Device Types</span>
             {deviceTypeFilter.length > 0 && (
-              <button onClick={resetFilters} className="text-accent-light text-[10px]">Clear</button>
+              <button onClick={resetFilters} className="text-nd-accent text-[10px] font-mono uppercase">Clear</button>
             )}
           </div>
           {deviceTypes.map((type) => {
             const active = deviceTypeFilter.includes(type);
             return (
-              <label key={type} className="flex items-center gap-2 px-2 py-1 rounded hover:bg-bg-tertiary cursor-pointer">
-                <div className={`w-3.5 h-3.5 rounded border flex items-center justify-center ${
-                  active ? 'bg-accent border-accent' : 'border-border-light'
+              <label key={type} className="flex items-center gap-2 px-2 py-1 rounded-nd-technical hover:bg-nd-surface-raised cursor-pointer">
+                <div className={`w-3.5 h-3.5 rounded-nd-technical border flex items-center justify-center ${
+                  active ? 'bg-black border-black' : 'border-nd-border-visible'
                 }`}>
                   {active && <svg width="8" height="8" viewBox="0 0 8 8" fill="none"><path d="M1.5 4L3 5.5L6.5 2" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>}
                 </div>
-                <div className="w-2 h-2 rounded-full" style={{ backgroundColor: typeColors[type] }} />
-                <span className={`text-[12px] capitalize ${active ? 'text-text-primary' : 'text-text-secondary'}`}>{type}</span>
+                <span className={`font-mono text-label uppercase tracking-[0.06em] ${active ? 'text-nd-text-primary' : 'text-nd-text-secondary'}`}>{type}</span>
               </label>
             );
           })}
         </div>
       )}
 
-      <div className="flex items-center bg-bg-secondary border border-border rounded-lg p-0.5 shadow-lg">
-        <button onClick={() => { setShowLayoutMenu(!showLayoutMenu); setShowFilterMenu(false); }} className={showLayoutMenu ? btnOn : btnOff} title="Layout"><Layout size={15} /></button>
+      {/* Control bar */}
+      <div className="flex items-center bg-nd-surface border border-nd-border-visible rounded-nd-compact p-0.5">
+        <button onClick={() => { setShowLayoutMenu(!showLayoutMenu); setShowFilterMenu(false); }} className={showLayoutMenu ? btnOn : btnOff} title="Layout"><Layout size={15} strokeWidth={1.5} /></button>
         <button onClick={() => { setShowFilterMenu(!showFilterMenu); setShowLayoutMenu(false); }} className={`${deviceTypeFilter.length > 0 || showFilterMenu ? btnOn : btnOff} relative`} title="Filter">
-          <Filter size={15} />
-          {deviceTypeFilter.length > 0 && <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full bg-accent" />}
+          <Filter size={15} strokeWidth={1.5} />
+          {deviceTypeFilter.length > 0 && <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full bg-nd-accent" />}
         </button>
-        <div className="w-px h-5 bg-border mx-0.5" />
-        <button onClick={() => setShowLabels(!showLabels)} className={showLabels ? btnOn : btnOff} title="Labels"><Tag size={15} /></button>
-        <button onClick={() => setShowRiskHalos(!showRiskHalos)} className={showRiskHalos ? `${btnBase} text-status-offline bg-status-offline/10` : btnOff} title="Risk Halos"><Activity size={15} /></button>
-        <div className="w-px h-5 bg-border mx-0.5" />
-        <button onClick={onZoomIn} className={btnOff} title="Zoom In"><ZoomIn size={15} /></button>
-        <button onClick={onZoomOut} className={btnOff} title="Zoom Out"><ZoomOut size={15} /></button>
-        <button onClick={onFit} className={btnOff} title="Fit"><Maximize2 size={15} /></button>
+        <div className="w-px h-5 bg-nd-border mx-0.5" />
+        <button onClick={() => setShowLabels(!showLabels)} className={showLabels ? btnOn : btnOff} title="Labels"><Tag size={15} strokeWidth={1.5} /></button>
+        <button onClick={() => setShowRiskHalos(!showRiskHalos)} className={showRiskHalos ? `${btnBase} text-nd-accent bg-nd-accent/10` : btnOff} title="Risk"><Activity size={15} strokeWidth={1.5} /></button>
+        <div className="w-px h-5 bg-nd-border mx-0.5" />
+        <button onClick={onZoomIn} className={btnOff} title="Zoom In"><ZoomIn size={15} strokeWidth={1.5} /></button>
+        <button onClick={onZoomOut} className={btnOff} title="Zoom Out"><ZoomOut size={15} strokeWidth={1.5} /></button>
+        <button onClick={onFit} className={btnOff} title="Fit"><Maximize2 size={15} strokeWidth={1.5} /></button>
       </div>
     </div>
   );

--- a/network-topology-mapper/frontend/src/components/graph/LayerToggle.tsx
+++ b/network-topology-mapper/frontend/src/components/graph/LayerToggle.tsx
@@ -4,27 +4,26 @@ import type { LayerType } from '../../types/topology';
 const layers: { value: LayerType; label: string }[] = [
   { value: 'physical', label: 'Physical' },
   { value: 'logical', label: 'Logical' },
-  { value: 'application', label: 'Application' },
+  { value: 'application', label: 'App' },
 ];
 
 export default function LayerToggle() {
   const { activeLayer, setActiveLayer } = useFilterStore();
 
   return (
-    <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10 flex bg-bg-secondary border border-border rounded-lg overflow-hidden">
-      {layers.map(({ value, label }) => (
-        <button
-          key={value}
-          onClick={() => setActiveLayer(value)}
-          className={`px-3 py-1.5 text-[12px] font-medium transition-colors ${
-            activeLayer === value
-              ? 'bg-accent/10 text-accent-light'
-              : 'text-text-muted hover:text-text-secondary hover:bg-bg-tertiary'
-          }`}
-        >
-          {label}
-        </button>
-      ))}
+    <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10 flex border border-nd-border-visible rounded-nd-pill overflow-hidden bg-nd-surface">
+      {layers.map(({ value, label }) => {
+        const isActive = activeLayer === value;
+        return (
+          <button
+            key={value}
+            onClick={() => setActiveLayer(value)}
+            className={`px-4 py-1.5 font-mono text-label uppercase tracking-[0.08em] transition-colors ${isActive ? 'bg-black text-white' : 'text-nd-text-secondary hover:text-nd-text-primary'}`}
+          >
+            {label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/network-topology-mapper/frontend/src/components/graph/MiniMap.tsx
+++ b/network-topology-mapper/frontend/src/components/graph/MiniMap.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react';
 import type { Core } from 'cytoscape';
-import { DEVICE_TYPE_COLORS } from '../../lib/graph-utils';
 
 interface Props {
   cy: Core | null;
@@ -19,7 +18,7 @@ export default function MiniMap({ cy }: Props) {
     const draw = () => {
       const { width, height } = canvas;
       ctx.clearRect(0, 0, width, height);
-      ctx.fillStyle = '#19191B';
+      ctx.fillStyle = '#FFFFFF';
       ctx.fillRect(0, 0, width, height);
 
       const bb = cy.elements().boundingBox();
@@ -32,7 +31,8 @@ export default function MiniMap({ cy }: Props) {
       const offsetX = padding + (width - padding * 2 - bb.w * scale) / 2;
       const offsetY = padding + (height - padding * 2 - bb.h * scale) / 2;
 
-      ctx.strokeStyle = 'rgba(255, 255, 255, 0.06)';
+      // Edges — subtle gray
+      ctx.strokeStyle = 'rgba(0, 0, 0, 0.08)';
       ctx.lineWidth = 0.5;
       cy.edges().forEach((edge) => {
         const src = edge.source().position();
@@ -43,19 +43,20 @@ export default function MiniMap({ cy }: Props) {
         ctx.stroke();
       });
 
+      // Nodes — dark dots
       cy.nodes().forEach((node) => {
         const pos = node.position();
         const x = (pos.x - bb.x1) * scale + offsetX;
         const y = (pos.y - bb.y1) * scale + offsetY;
-        const deviceType = node.data('device_type') as string;
-        ctx.fillStyle = DEVICE_TYPE_COLORS[deviceType as keyof typeof DEVICE_TYPE_COLORS] || '#5C5C5F';
+        ctx.fillStyle = '#1A1A1A';
         ctx.beginPath();
-        ctx.arc(x, y, 2.5, 0, Math.PI * 2);
+        ctx.arc(x, y, 2, 0, Math.PI * 2);
         ctx.fill();
       });
 
+      // Viewport rect
       const ext = cy.extent();
-      ctx.strokeStyle = 'rgba(99, 102, 241, 0.4)';
+      ctx.strokeStyle = 'rgba(0, 0, 0, 0.25)';
       ctx.lineWidth = 1;
       ctx.strokeRect(
         (ext.x1 - bb.x1) * scale + offsetX,
@@ -76,7 +77,7 @@ export default function MiniMap({ cy }: Props) {
         ref={canvasRef}
         width={140}
         height={90}
-        className="rounded-lg border border-border bg-bg-secondary"
+        className="rounded-nd-compact border border-nd-border-visible bg-nd-surface"
       />
     </div>
   );

--- a/network-topology-mapper/frontend/src/components/graph/NetworkCanvas.tsx
+++ b/network-topology-mapper/frontend/src/components/graph/NetworkCanvas.tsx
@@ -5,11 +5,10 @@ import dagre from 'cytoscape-dagre';
 import { useTopologyStore } from '../../stores/topologyStore';
 import { useFilterStore } from '../../stores/filterStore';
 import { cytoscapeStylesheet, getLayoutOptions } from '../../lib/cytoscape-config';
-import { DEVICE_TYPE_COLORS, truncate } from '../../lib/graph-utils';
+import { truncate } from '../../lib/graph-utils';
 import GraphControls from './GraphControls';
 import LayerToggle from './LayerToggle';
 import MiniMap from './MiniMap';
-import NodeTooltip from './NodeTooltip';
 
 try { cytoscape.use(cola); } catch {}
 try { cytoscape.use(dagre); } catch {}
@@ -17,12 +16,11 @@ try { cytoscape.use(dagre); } catch {}
 export default function NetworkCanvas() {
   const containerRef = useRef<HTMLDivElement>(null);
   const cyRef = useRef<Core | null>(null);
-  const tooltipRef = useRef<{ deviceId: string; x: number; y: number } | null>(null);
   const [cyReady, setCyReady] = useState(0);
 
   const {
     devices, connections, dependencies,
-    selectedDeviceId, selectDevice,
+    selectedDeviceId, selectDevice, setRightPanelContent,
     simulationActive, simulationResult,
     spofs,
   } = useTopologyStore();
@@ -41,47 +39,38 @@ export default function NetworkCanvas() {
       wheelSensitivity: 0.3,
     });
 
-    cy.on('tap', 'node', (evt: EventObject) => selectDevice(evt.target.id()));
-    cy.on('tap', (evt: EventObject) => { if (evt.target === cy) selectDevice(null); });
+    // Click node → open inspector panel
+    cy.on('tap', 'node', (evt: EventObject) => {
+      selectDevice(evt.target.id());
+      setRightPanelContent('device');
+    });
+    // Click canvas background → close panel
+    cy.on('tap', (evt: EventObject) => {
+      if (evt.target === cy) {
+        selectDevice(null);
+        setRightPanelContent(null);
+      }
+    });
 
+    // Hover → show hostname label + neighborhood highlight
     cy.on('mouseover', 'node', (evt: EventObject) => {
       const node = evt.target;
-      const pos = node.renderedPosition();
-      tooltipRef.current = { deviceId: node.id(), x: pos.x, y: pos.y };
-      containerRef.current?.dispatchEvent(new CustomEvent('node-hover', { detail: tooltipRef.current }));
+      node.addClass('hovered');
       const neighborhood = node.closedNeighborhood();
       cy.elements().addClass('dimmed');
       neighborhood.removeClass('dimmed').addClass('highlighted');
     });
 
     cy.on('mouseout', 'node', () => {
-      tooltipRef.current = null;
-      containerRef.current?.dispatchEvent(new CustomEvent('node-hover', { detail: null }));
-      cy.elements().removeClass('dimmed highlighted');
+      cy.elements().removeClass('dimmed highlighted hovered');
     });
 
     cy.on('mouseover', 'edge', (evt: EventObject) => {
-      const edge = evt.target;
-      edge.addClass('edge-hovered');
-      const midpoint = edge.midpoint();
-      const z = cy.zoom();
-      const pan = cy.pan();
-      containerRef.current?.dispatchEvent(new CustomEvent('edge-hover', {
-        detail: {
-          x: midpoint.x * z + pan.x,
-          y: midpoint.y * z + pan.y,
-          connection_type: edge.data('connection_type') || 'unknown',
-          bandwidth: edge.data('bandwidth') || 'N/A',
-          latency: edge.data('latency_ms'),
-          status: edge.data('status') || 'active',
-          is_redundant: edge.data('is_redundant') || false,
-        },
-      }));
+      evt.target.addClass('edge-hovered');
     });
 
     cy.on('mouseout', 'edge', () => {
       cy.edges().removeClass('edge-hovered');
-      containerRef.current?.dispatchEvent(new CustomEvent('edge-hover', { detail: null }));
     });
 
     cy.on('dbltap', 'node', (evt: EventObject) => {
@@ -92,7 +81,7 @@ export default function NetworkCanvas() {
     cyRef.current = cy;
     setCyReady((c) => c + 1);
     return () => { cy.destroy(); cyRef.current = null; };
-  }, [selectDevice]);
+  }, [selectDevice, setRightPanelContent]);
 
   useEffect(() => {
     const cy = cyRef.current;
@@ -180,10 +169,9 @@ export default function NetworkCanvas() {
   return (
     <div className="relative w-full h-full">
       <LayerToggle />
-      <div ref={containerRef} className="w-full h-full bg-bg-primary" />
+      <div ref={containerRef} className="w-full h-full bg-nd-black dot-grid-subtle" />
       <MiniMap cy={cyRef.current} key={cyReady} />
       <GraphControls onFit={handleFit} onZoomIn={handleZoomIn} onZoomOut={handleZoomOut} />
-      <NodeTooltip containerRef={containerRef} devices={devices} />
     </div>
   );
 }

--- a/network-topology-mapper/frontend/src/components/graph/NodeTooltip.tsx
+++ b/network-topology-mapper/frontend/src/components/graph/NodeTooltip.tsx
@@ -1,9 +1,6 @@
 import { useState, useEffect, RefObject } from 'react';
 import type { Device } from '../../types/topology';
-import DeviceIcon from '../shared/DeviceIcon';
-import StatusBadge from '../shared/StatusBadge';
-import { formatTimeAgo, getRiskColor, CONNECTION_TYPE_COLORS } from '../../lib/graph-utils';
-import { Cable, Wifi, Globe, Shield, Zap } from 'lucide-react';
+import { formatTimeAgo, getRiskColor } from '../../lib/graph-utils';
 
 interface Props {
   containerRef: RefObject<HTMLDivElement>;
@@ -15,10 +12,6 @@ interface EdgeTooltipData {
   connection_type: string; bandwidth: string;
   latency: number | undefined; status: string; is_redundant: boolean;
 }
-
-const CONNECTION_ICONS: Record<string, typeof Cable> = {
-  ethernet: Cable, fiber: Zap, wireless: Wifi, vpn: Shield, virtual: Globe,
-};
 
 export default function NodeTooltip({ containerRef, devices }: Props) {
   const [tooltip, setTooltip] = useState<{ deviceId: string; x: number; y: number } | null>(null);
@@ -34,53 +27,89 @@ export default function NodeTooltip({ containerRef, devices }: Props) {
     return () => { el.removeEventListener('node-hover', nodeHandler); el.removeEventListener('edge-hover', edgeHandler); };
   }, [containerRef]);
 
+  // Edge tooltip
   if (edgeTooltip) {
-    const ConnIcon = CONNECTION_ICONS[edgeTooltip.connection_type] || Cable;
-    const color = CONNECTION_TYPE_COLORS[edgeTooltip.connection_type as keyof typeof CONNECTION_TYPE_COLORS] || '#5C5C5F';
-    const statusColor = edgeTooltip.status === 'active' ? '#34D399' : edgeTooltip.status === 'flapping' ? '#F87171' : '#FBBF24';
+    const statusColor = edgeTooltip.status === 'active' ? '#4A9E5C' : edgeTooltip.status === 'flapping' ? '#D71921' : '#D4A843';
 
     return (
-      <div className="absolute z-50 bg-bg-secondary border border-border rounded-lg shadow-lg pointer-events-none min-w-[200px] animate-fade-in" style={{ left: edgeTooltip.x + 16, top: edgeTooltip.y - 12 }}>
-        <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
-          <ConnIcon size={13} style={{ color }} />
-          <span className="text-[12px] font-medium capitalize" style={{ color }}>{edgeTooltip.connection_type}</span>
+      <div
+        className="absolute z-50 bg-nd-surface border border-nd-border-visible rounded-nd-compact pointer-events-none min-w-[200px] animate-fade-in"
+        style={{ left: edgeTooltip.x + 16, top: edgeTooltip.y - 12 }}
+      >
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-nd-border">
+          <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-primary">{edgeTooltip.connection_type}</span>
           <span className="ml-auto w-1.5 h-1.5 rounded-full" style={{ backgroundColor: statusColor }} />
         </div>
-        <div className="px-3 py-2 grid grid-cols-2 gap-x-4 gap-y-1.5 text-[12px]">
-          <div><div className="text-text-muted text-[10px]">Bandwidth</div><div className="text-text-secondary">{edgeTooltip.bandwidth}</div></div>
-          <div><div className="text-text-muted text-[10px]">Latency</div><div className="text-text-secondary">{edgeTooltip.latency != null ? `${edgeTooltip.latency}ms` : '—'}</div></div>
-          <div><div className="text-text-muted text-[10px]">Status</div><div className="capitalize" style={{ color: statusColor }}>{edgeTooltip.status}</div></div>
-          {edgeTooltip.is_redundant && <div><div className="text-text-muted text-[10px]">Redundant</div><div className="text-status-online">Yes</div></div>}
+        <div className="px-3 py-2 grid grid-cols-2 gap-x-4 gap-y-1.5">
+          <div>
+            <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Bandwidth</div>
+            <div className="font-mono text-caption text-nd-text-primary">{edgeTooltip.bandwidth}</div>
+          </div>
+          <div>
+            <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Latency</div>
+            <div className="font-mono text-caption text-nd-text-primary">{edgeTooltip.latency != null ? `${edgeTooltip.latency}ms` : '\u2014'}</div>
+          </div>
+          <div>
+            <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Status</div>
+            <div className="font-mono text-caption uppercase" style={{ color: statusColor }}>{edgeTooltip.status}</div>
+          </div>
+          {edgeTooltip.is_redundant && (
+            <div>
+              <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Redundant</div>
+              <div className="font-mono text-caption text-[#4A9E5C]">Yes</div>
+            </div>
+          )}
         </div>
       </div>
     );
   }
 
+  // Node tooltip
   if (!tooltip) return null;
   const device = devices.find((d) => d.id === tooltip.deviceId);
   if (!device) return null;
 
+  const statusColor = device.status === 'online' ? '#4A9E5C' : device.status === 'offline' ? '#D71921' : '#D4A843';
+
   return (
-    <div className="absolute z-50 bg-bg-secondary border border-border rounded-lg shadow-lg pointer-events-none min-w-[250px] animate-fade-in" style={{ left: tooltip.x + 20, top: tooltip.y - 20 }}>
-      <div className="flex items-center justify-between px-3 py-2 border-b border-border">
-        <div className="flex items-center gap-2">
-          <DeviceIcon type={device.device_type} size={14} />
-          <div>
-            <div className="text-[13px] font-medium text-text-primary">{device.hostname || 'Unknown'}</div>
-            <div className="text-[10px] text-text-muted capitalize">{device.device_type}</div>
-          </div>
+    <div
+      className="absolute z-50 bg-nd-surface border border-nd-border-visible rounded-nd-compact pointer-events-none min-w-[240px] animate-fade-in"
+      style={{ left: tooltip.x + 20, top: tooltip.y - 20 }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-nd-border">
+        <div>
+          <div className="text-body-sm font-sans font-medium text-nd-text-display">{device.hostname || 'Unknown'}</div>
+          <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">{device.device_type}</div>
         </div>
-        <StatusBadge status={device.status} size={8} />
+        <span className="w-2 h-2 rounded-full" style={{ backgroundColor: statusColor }} />
       </div>
-      <div className="px-3 py-2 grid grid-cols-2 gap-x-4 gap-y-1.5 text-[12px]">
-        <div><div className="text-text-muted text-[10px]">IP</div><div className="text-text-secondary font-mono">{device.ip}</div></div>
-        <div><div className="text-text-muted text-[10px]">Tier</div><div className="text-text-secondary">Level {device.tier}</div></div>
-        <div><div className="text-text-muted text-[10px]">Risk</div><div className="font-medium" style={{ color: getRiskColor(device.risk_score) }}>{device.risk_score.toFixed(1)}</div></div>
-        <div><div className="text-text-muted text-[10px]">Last seen</div><div className="text-text-muted">{formatTimeAgo(device.last_seen)}</div></div>
+
+      {/* Data grid */}
+      <div className="px-3 py-2 grid grid-cols-2 gap-x-4 gap-y-1.5">
+        <div>
+          <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">IP</div>
+          <div className="font-mono text-caption text-nd-text-primary">{device.ip}</div>
+        </div>
+        <div>
+          <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Tier</div>
+          <div className="font-mono text-caption text-nd-text-primary">Level {device.tier}</div>
+        </div>
+        <div>
+          <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Risk</div>
+          <div className="font-mono text-caption font-bold" style={{ color: getRiskColor(device.risk_score) }}>{device.risk_score.toFixed(1)}</div>
+        </div>
+        <div>
+          <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Last Seen</div>
+          <div className="font-mono text-caption text-nd-text-secondary">{formatTimeAgo(device.last_seen)}</div>
+        </div>
       </div>
+
+      {/* Footer */}
       {device.vendor && (
-        <div className="px-3 py-1.5 border-t border-border text-[10px] text-text-muted flex justify-between">
-          <span>{device.vendor}</span><span>{device.model || '—'}</span>
+        <div className="px-3 py-1.5 border-t border-nd-border font-mono text-label uppercase tracking-[0.06em] text-nd-text-disabled flex justify-between">
+          <span>{device.vendor}</span>
+          <span>{device.model || '\u2014'}</span>
         </div>
       )}
     </div>

--- a/network-topology-mapper/frontend/src/components/layout/AppShell.tsx
+++ b/network-topology-mapper/frontend/src/components/layout/AppShell.tsx
@@ -1,48 +1,33 @@
-import { useSettingsStore } from '../../stores/settingsStore';
 import { useTopologyStore } from '../../stores/topologyStore';
 import { useWebSocket } from '../../hooks/useWebSocket';
-import { Search } from 'lucide-react';
 import Sidebar from './Sidebar';
-import CommandPalette from './CommandPalette';
 
 interface Props {
   children: React.ReactNode;
 }
 
 export default function AppShell({ children }: Props) {
-  const { setCommandPaletteOpen } = useSettingsStore();
   const { stats } = useTopologyStore();
   const { connected } = useWebSocket();
 
   return (
-    <div className="flex h-screen w-screen bg-bg-primary text-text-primary overflow-hidden">
+    <div className="flex h-screen w-screen bg-nd-black text-nd-text-primary overflow-hidden">
       <Sidebar />
 
       <div className="flex flex-col flex-1 overflow-hidden">
         {/* Header */}
-        <header className="flex items-center justify-between px-6 h-12 flex-shrink-0 border-b border-border">
-          <div className="flex items-center gap-3">
-            <h1 className="text-sm font-semibold text-text-primary">Topology</h1>
-            <span className="text-xs text-text-muted">
-              {stats ? `${stats.total_devices} devices` : '—'}
+        <header className="flex items-center px-6 h-12 flex-shrink-0 border-b border-nd-border bg-nd-surface">
+          <div className="flex items-center gap-4">
+            <h1 className="font-mono text-label uppercase tracking-[0.08em] text-black">Topology</h1>
+            <span className="font-mono text-caption text-nd-text-secondary">
+              {stats ? `${stats.total_devices} devices` : '\u2014'}
             </span>
-            <div className="flex items-center gap-1.5 ml-1">
-              <span className={`w-1.5 h-1.5 rounded-full ${connected ? 'bg-status-online' : 'bg-status-offline'}`} />
-              <span className="text-[11px] text-text-muted">
+            <div className="flex items-center gap-1.5">
+              <span className={`w-1.5 h-1.5 rounded-full ${connected ? 'bg-nd-success' : 'bg-nd-accent'}`} />
+              <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">
                 {connected ? 'Connected' : 'Disconnected'}
               </span>
             </div>
-          </div>
-
-          <div className="flex items-center gap-3">
-            <button
-              onClick={() => setCommandPaletteOpen(true)}
-              className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-bg-tertiary border border-border text-text-muted text-xs hover:text-text-secondary hover:border-border-light transition-colors"
-            >
-              <Search size={13} />
-              <span>Search...</span>
-              <kbd className="hidden sm:inline text-[10px] text-text-muted bg-bg-primary border border-border rounded px-1 py-px ml-2">⌘K</kbd>
-            </button>
           </div>
         </header>
 
@@ -51,8 +36,6 @@ export default function AppShell({ children }: Props) {
           {children}
         </main>
       </div>
-
-      <CommandPalette />
     </div>
   );
 }

--- a/network-topology-mapper/frontend/src/components/layout/CommandPalette.tsx
+++ b/network-topology-mapper/frontend/src/components/layout/CommandPalette.tsx
@@ -34,7 +34,7 @@ export default function CommandPalette() {
 
     devices.forEach((d) => {
       if (d.hostname.toLowerCase().includes(q) || d.ip.includes(q) || d.mac.toLowerCase().includes(q) || d.device_type.includes(q)) {
-        items.push({ type: 'device', id: d.id, label: d.hostname || d.ip, sublabel: `${d.ip} — ${d.device_type}`, deviceType: d.device_type });
+        items.push({ type: 'device', id: d.id, label: d.hostname || d.ip, sublabel: `${d.ip} \u2014 ${d.device_type}`, deviceType: d.device_type });
       }
     });
 
@@ -61,31 +61,47 @@ export default function CommandPalette() {
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center pt-[20vh]">
-      <div className="fixed inset-0 bg-black/60" onClick={() => setCommandPaletteOpen(false)} />
-      <div className="relative w-[500px] bg-bg-secondary border border-border rounded-lg shadow-2xl overflow-hidden animate-fade-in">
-        <div className="flex items-center gap-2.5 px-4 py-3 border-b border-border">
-          <Search size={15} className="text-text-muted" />
-          <input autoFocus value={query} onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search devices, navigate..." className="flex-1 bg-transparent text-text-primary text-sm outline-none placeholder:text-text-muted" />
-          <kbd className="text-[10px] text-text-muted bg-bg-tertiary border border-border rounded px-1.5 py-0.5">ESC</kbd>
+      {/* Backdrop */}
+      <div className="fixed inset-0 bg-black/40" onClick={() => setCommandPaletteOpen(false)} />
+
+      {/* Dialog */}
+      <div className="relative w-[500px] bg-nd-surface border border-nd-border-visible rounded-nd-card overflow-hidden animate-fade-in">
+        {/* Search input */}
+        <div className="flex items-center gap-2.5 px-4 py-3 border-b border-nd-border">
+          <Search size={15} strokeWidth={1.5} className="text-nd-text-disabled" />
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search devices, navigate..."
+            className="flex-1 bg-transparent text-nd-text-primary text-body-sm font-sans outline-none placeholder:text-nd-text-disabled"
+          />
+          <kbd className="font-mono text-[10px] text-nd-text-disabled border border-nd-border rounded-nd-technical px-1.5 py-0.5">ESC</kbd>
         </div>
+
+        {/* Results */}
         {results.length > 0 && (
           <div className="max-h-72 overflow-y-auto py-1">
             {results.map((result, i) => (
-              <button key={`${result.type}-${result.id}-${i}`} onClick={() => handleSelect(result)}
-                className="w-full flex items-center gap-2.5 px-4 py-2 text-left hover:bg-bg-tertiary transition-colors">
+              <button
+                key={`${result.type}-${result.id}-${i}`}
+                onClick={() => handleSelect(result)}
+                className="w-full flex items-center gap-2.5 px-4 py-2 text-left hover:bg-nd-surface-raised transition-colors"
+              >
                 {result.type === 'device' && result.deviceType && <DeviceIcon type={result.deviceType as any} size={15} />}
-                {result.type === 'nav' && <Search size={13} className="text-text-muted" />}
+                {result.type === 'nav' && <Search size={13} strokeWidth={1.5} className="text-nd-text-disabled" />}
                 <div className="flex-1 min-w-0">
-                  <div className="text-[13px] text-text-primary truncate">{result.label}</div>
-                  {result.sublabel && <div className="text-[11px] text-text-muted truncate">{result.sublabel}</div>}
+                  <div className="text-body-sm text-nd-text-primary truncate">{result.label}</div>
+                  {result.sublabel && <div className="font-mono text-label text-nd-text-disabled truncate">{result.sublabel}</div>}
                 </div>
-                <span className="text-[10px] text-text-muted uppercase">{result.type}</span>
+                <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">{result.type}</span>
               </button>
             ))}
           </div>
         )}
-        {query && results.length === 0 && <div className="px-4 py-6 text-center text-text-muted text-sm">No results</div>}
+        {query && results.length === 0 && (
+          <div className="px-4 py-6 text-center text-nd-text-secondary text-body-sm">[NO RESULTS]</div>
+        )}
       </div>
     </div>
   );

--- a/network-topology-mapper/frontend/src/components/layout/Sidebar.tsx
+++ b/network-topology-mapper/frontend/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import {
-  Map, LayoutDashboard, Search, Zap, Bell, BarChart3, Clock, FileText, Settings, Network,
+  Map, LayoutDashboard, Search, Zap, Bell, BarChart3, Clock, FileText, Settings,
 } from 'lucide-react';
 import { useTopologyStore } from '../../stores/topologyStore';
 import type { ViewType } from '../../types/topology';
@@ -40,15 +40,14 @@ export default function Sidebar() {
   };
 
   return (
-    <aside className="h-full w-[200px] flex-shrink-0 border-r border-border bg-bg-primary flex flex-col">
+    <aside className="h-full w-[200px] flex-shrink-0 border-r border-nd-border bg-nd-surface flex flex-col">
       {/* Logo */}
-      <div className="h-12 flex items-center px-4 border-b border-border gap-2.5">
-        <Network size={18} className="text-accent" />
-        <span className="text-sm font-semibold">NTS</span>
+      <div className="h-12 flex items-center px-4 border-b border-nd-border gap-2.5">
+        <span className="font-display text-heading font-bold text-black tracking-tight">NTS</span>
       </div>
 
       {/* Nav */}
-      <nav className="flex-1 py-2 px-2 space-y-0.5 overflow-y-auto">
+      <nav className="flex-1 py-3 px-2 space-y-0.5 overflow-y-auto">
         {navItems.map(({ icon: Icon, label, view }) => {
           const isActive = currentView === view;
           return (
@@ -56,18 +55,25 @@ export default function Sidebar() {
               key={view}
               onClick={() => handleNavClick(view)}
               className={`
-                w-full flex items-center gap-2.5 px-2.5 py-[7px] rounded-md text-[13px] transition-colors relative
+                w-full flex items-center gap-3 px-3 py-2 rounded-nd-compact transition-colors relative
+                font-mono text-label uppercase tracking-[0.08em]
                 ${isActive
-                  ? 'bg-bg-tertiary text-text-primary font-medium'
-                  : 'text-text-secondary hover:text-text-primary hover:bg-bg-secondary'
+                  ? 'bg-nd-surface-raised text-nd-text-display'
+                  : 'text-nd-text-disabled hover:text-nd-text-primary hover:bg-nd-surface-raised'
                 }
               `}
             >
-              <Icon size={15} className={isActive ? 'text-accent-light' : ''} />
+              <Icon size={15} strokeWidth={1.5} className={isActive ? 'text-nd-text-display' : ''} />
               <span>{label}</span>
 
+              {/* Active indicator — dot */}
+              {isActive && (
+                <span className="ml-auto w-1.5 h-1.5 rounded-full bg-nd-accent" />
+              )}
+
+              {/* Alert badge */}
               {view === 'alerts' && alertCount > 0 && (
-                <span className="ml-auto flex h-4 min-w-[16px] items-center justify-center rounded-full bg-status-offline text-[10px] font-medium text-white px-1">
+                <span className="ml-auto flex h-4 min-w-[16px] items-center justify-center rounded-nd-pill bg-nd-accent text-[10px] font-mono font-bold text-white px-1">
                   {alertCount > 9 ? '9+' : alertCount}
                 </span>
               )}

--- a/network-topology-mapper/frontend/src/components/panels/AlertFeed.tsx
+++ b/network-topology-mapper/frontend/src/components/panels/AlertFeed.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { X, Filter, Eye, XCircle } from 'lucide-react';
+import { X, Filter, Eye } from 'lucide-react';
 import { useAlerts } from '../../hooks/useAlerts';
 import { useTopologyStore } from '../../stores/topologyStore';
 import { getSeverityColor, formatTimeAgo } from '../../lib/graph-utils';
@@ -21,39 +21,41 @@ export default function AlertFeed() {
   });
 
   return (
-    <div className="w-[380px] h-full bg-bg-secondary border-l border-bg-tertiary flex flex-col animate-slide-in-right">
-      <div className="sticky top-0 bg-bg-secondary border-b border-bg-tertiary px-4 py-3 flex items-center justify-between z-10 flex-shrink-0">
-        <span className="text-sm font-semibold text-text-primary">Alerts</span>
+    <div className="w-[380px] flex-shrink-0 h-full bg-nd-surface border-l border-nd-border flex flex-col animate-fade-in">
+      {/* Header */}
+      <div className="sticky top-0 bg-nd-surface border-b border-nd-border px-4 py-3 flex items-center justify-between z-10 flex-shrink-0">
+        <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Alerts</span>
         <div className="flex items-center gap-2">
           <button
             onClick={() => setShowFilters(!showFilters)}
-            className={`text-xs px-2 py-1 rounded transition-colors ${
-              showFilters ? 'bg-node-switch/20 text-node-switch' : 'text-text-muted hover:text-text-primary'
+            className={`p-1 rounded-nd-technical transition-colors ${
+              showFilters ? 'bg-nd-surface-raised text-nd-text-display' : 'text-nd-text-disabled hover:text-nd-text-primary'
             }`}
           >
-            <Filter size={14} />
+            <Filter size={14} strokeWidth={1.5} />
           </button>
           <button
             onClick={() => setRightPanelContent(null)}
-            className="text-text-muted hover:text-text-primary transition-colors"
+            className="text-nd-text-disabled hover:text-nd-text-primary transition-colors"
           >
-            <X size={16} />
+            <X size={16} strokeWidth={1.5} />
           </button>
         </div>
       </div>
 
+      {/* Filters */}
       {showFilters && (
-        <div className="px-4 py-2 border-b border-bg-tertiary flex gap-2 flex-wrap flex-shrink-0">
+        <div className="px-4 py-2 border-b border-nd-border flex gap-1.5 flex-wrap flex-shrink-0">
           {severityOrder.map((sev) => (
             <button
               key={sev}
               onClick={() => setFilterSeverity(filterSeverity === sev ? null : sev)}
-              className={`text-[10px] px-2 py-0.5 rounded-full capitalize transition-colors ${
+              className={`font-mono text-label uppercase tracking-[0.06em] px-2 py-0.5 rounded-nd-pill border transition-colors ${
                 filterSeverity === sev
-                  ? 'text-white'
-                  : 'text-text-muted bg-bg-tertiary hover:text-text-secondary'
+                  ? 'border-current text-white'
+                  : 'border-nd-border-visible text-nd-text-disabled hover:text-nd-text-secondary'
               }`}
-              style={filterSeverity === sev ? { backgroundColor: getSeverityColor(sev) } : {}}
+              style={filterSeverity === sev ? { backgroundColor: getSeverityColor(sev), borderColor: getSeverityColor(sev) } : {}}
             >
               {sev}
             </button>
@@ -61,38 +63,41 @@ export default function AlertFeed() {
         </div>
       )}
 
+      {/* Alert list */}
       <div className="flex-1 overflow-y-auto">
         {loading && (
-          <div className="p-4 text-center text-text-muted text-xs">Loading alerts...</div>
+          <div className="p-4 text-center font-mono text-caption text-nd-text-disabled">[LOADING...]</div>
         )}
 
         {!loading && filteredAlerts.length === 0 && (
-          <div className="p-8 text-center text-text-muted text-sm">No alerts</div>
+          <div className="p-8 text-center">
+            <div className="font-mono text-caption text-nd-text-disabled">[NO ALERTS]</div>
+          </div>
         )}
 
         {filteredAlerts.map((alert) => (
           <div
             key={alert.id}
-            className="px-4 py-3 border-b border-bg-tertiary/50 hover:bg-bg-tertiary/30 transition-colors animate-fade-in"
-            style={{ borderLeftWidth: 3, borderLeftColor: getSeverityColor(alert.severity) }}
+            className="px-4 py-3 border-b border-nd-border hover:bg-nd-surface-raised transition-colors animate-fade-in"
+            style={{ borderLeftWidth: 2, borderLeftColor: getSeverityColor(alert.severity) }}
           >
             <div className="flex items-center justify-between mb-1">
               <span
-                className="text-[10px] font-bold uppercase"
+                className="font-mono text-label uppercase tracking-[0.08em] font-bold"
                 style={{ color: getSeverityColor(alert.severity) }}
               >
                 {alert.severity}
               </span>
-              <span className="text-[10px] text-text-muted">{formatTimeAgo(alert.created_at)}</span>
+              <span className="font-mono text-label text-nd-text-disabled">{formatTimeAgo(alert.created_at)}</span>
             </div>
 
-            <h4 className="text-xs font-medium text-text-primary mb-0.5">{alert.title}</h4>
+            <h4 className="text-body-sm font-sans font-medium text-nd-text-primary mb-0.5">{alert.title}</h4>
             {alert.description && (
-              <p className="text-[11px] text-text-secondary mb-2">{alert.description}</p>
+              <p className="text-caption text-nd-text-secondary mb-2">{alert.description}</p>
             )}
 
             {alert.status === 'open' && (
-              <div className="flex gap-2">
+              <div className="flex gap-3">
                 {alert.device_id && (
                   <button
                     onClick={() => {
@@ -100,21 +105,21 @@ export default function AlertFeed() {
                       setCurrentView('topology');
                       setRightPanelContent('device');
                     }}
-                    className="text-[10px] text-node-switch hover:underline flex items-center gap-1"
+                    className="font-mono text-label uppercase tracking-[0.06em] text-nd-interactive hover:underline flex items-center gap-1"
                   >
-                    <Eye size={10} />
+                    <Eye size={10} strokeWidth={1.5} />
                     Investigate
                   </button>
                 )}
                 <button
                   onClick={() => acknowledgeAlert(alert.id)}
-                  className="text-[10px] text-text-muted hover:text-text-primary"
+                  className="font-mono text-label uppercase tracking-[0.06em] text-nd-text-disabled hover:text-nd-text-primary"
                 >
                   Acknowledge
                 </button>
                 <button
                   onClick={() => dismissAlert(alert.id)}
-                  className="text-[10px] text-text-muted hover:text-risk-critical"
+                  className="font-mono text-label uppercase tracking-[0.06em] text-nd-text-disabled hover:text-nd-accent"
                 >
                   Dismiss
                 </button>
@@ -122,7 +127,7 @@ export default function AlertFeed() {
             )}
 
             {alert.status !== 'open' && (
-              <span className="text-[10px] text-text-muted capitalize">{alert.status}</span>
+              <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">[{alert.status}]</span>
             )}
           </div>
         ))}

--- a/network-topology-mapper/frontend/src/components/panels/DeviceInspector.tsx
+++ b/network-topology-mapper/frontend/src/components/panels/DeviceInspector.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { X, ExternalLink, AlertTriangle, Zap, Route, FileText } from 'lucide-react';
+import { X, Zap, Route } from 'lucide-react';
 import { useTopologyStore } from '../../stores/topologyStore';
 import { fetchDevice, fetchDeviceDependencies } from '../../lib/api';
 import DeviceIcon from '../shared/DeviceIcon';
@@ -22,11 +22,9 @@ export default function DeviceInspector() {
       return;
     }
 
-    // First try local store
     const local = devices.find((d) => d.id === selectedDeviceId);
     if (local) setDevice(local);
 
-    // Then fetch full details from API
     fetchDevice(selectedDeviceId)
       .then((d) => { if (d && !d.error) setDevice(d); })
       .catch(() => {});
@@ -55,28 +53,29 @@ export default function DeviceInspector() {
   };
 
   return (
-    <div className="w-[380px] h-full bg-bg-secondary border-l border-bg-tertiary overflow-y-auto animate-slide-in-right">
-      <div className="sticky top-0 bg-bg-secondary border-b border-bg-tertiary px-4 py-3 flex items-center justify-between z-10">
-        <span className="text-sm font-semibold text-text-primary">Device Inspector</span>
+    <div className="w-[380px] flex-shrink-0 h-full bg-nd-surface border-l border-nd-border overflow-y-auto animate-fade-in">
+      {/* Header */}
+      <div className="sticky top-0 bg-nd-surface border-b border-nd-border px-4 py-3 flex items-center justify-between z-10">
+        <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Device Inspector</span>
         <button
           onClick={() => selectDevice(null)}
-          className="text-text-muted hover:text-text-primary transition-colors"
+          className="text-nd-text-disabled hover:text-nd-text-primary transition-colors"
         >
-          <X size={16} />
+          <X size={16} strokeWidth={1.5} />
         </button>
       </div>
 
-      <div className="p-4 space-y-4">
-        {/* Header */}
+      <div className="p-4 space-y-5">
+        {/* Device identity header */}
         <div className="flex items-start gap-3">
-          <div className="w-10 h-10 rounded-lg bg-bg-tertiary flex items-center justify-center flex-shrink-0">
+          <div className="w-10 h-10 rounded-nd-compact bg-nd-surface-raised border border-nd-border flex items-center justify-center flex-shrink-0">
             <DeviceIcon type={device.device_type} size={22} />
           </div>
           <div>
-            <h3 className="text-base font-semibold text-text-primary">
+            <h3 className="text-subheading font-sans font-medium text-nd-text-display">
               {device.hostname || device.ip}
             </h3>
-            <p className="text-xs text-text-secondary">
+            <p className="font-mono text-caption text-nd-text-secondary">
               {device.vendor} {device.model}
               {device.os && ` \u00b7 ${device.os}`}
             </p>
@@ -87,15 +86,14 @@ export default function DeviceInspector() {
         </div>
 
         {/* Risk Score */}
-        <div className="bg-bg-tertiary rounded-lg p-3">
-          <div className="text-xs text-text-muted mb-2">Risk Score</div>
+        <div className="bg-nd-surface-raised rounded-nd-compact p-3 border border-nd-border">
+          <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled mb-2">Risk Score</div>
           <RiskScore score={device.risk_score} size="md" />
           {device.risk_details?.factors && device.risk_details.factors.length > 0 && (
-            <div className="mt-2 text-xs text-text-muted">
-              {device.risk_details.factors.map((f, i) => (
-                <div key={i} className="flex items-start gap-1 mt-0.5">
-                  <AlertTriangle size={10} className="flex-shrink-0 mt-0.5 text-risk-medium" />
-                  <span>{f}</span>
+            <div className="mt-2 space-y-0.5">
+              {device.risk_details.factors.map((f: string, i: number) => (
+                <div key={i} className="font-mono text-caption text-nd-text-secondary">
+                  {'\u2022'} {f}
                 </div>
               ))}
             </div>
@@ -108,8 +106,8 @@ export default function DeviceInspector() {
           <InfoRow label="MAC" value={device.mac} />
           <InfoRow label="Vendor" value={device.vendor} />
           <InfoRow label="Type" value={device.device_type} />
-          <InfoRow label="First seen" value={formatDate(device.first_seen)} />
-          <InfoRow label="Last seen" value={formatTimeAgo(device.last_seen)} />
+          <InfoRow label="First Seen" value={formatDate(device.first_seen)} />
+          <InfoRow label="Last Seen" value={formatTimeAgo(device.last_seen)} />
           <InfoRow label="Discovery" value={device.discovery_method} />
         </Section>
 
@@ -127,14 +125,36 @@ export default function DeviceInspector() {
           <Section title="Open Ports">
             <div className="space-y-1">
               {device.open_ports.map((port, i) => (
-                <div key={port} className="flex items-center justify-between text-xs">
-                  <span className="text-text-primary font-mono">{port}/tcp</span>
-                  <span className="text-text-secondary">
+                <div key={port} className="flex items-center justify-between">
+                  <span className="font-mono text-caption text-nd-text-primary">{port}/tcp</span>
+                  <span className="font-mono text-caption text-nd-text-secondary">
                     {device.services[i] || 'unknown'}
                   </span>
-                  <span className="text-status-online text-[10px]">open</span>
+                  <span className="font-mono text-label uppercase text-nd-success">open</span>
                 </div>
               ))}
+            </div>
+          </Section>
+        )}
+
+        {/* Connected Devices */}
+        {deviceConns.length > 0 && (
+          <Section title={`Connected To (${deviceConns.length})`}>
+            <div className="space-y-1">
+              {deviceConns.map((conn) => {
+                const peerId = conn.source_id === device.id ? conn.target_id : conn.source_id;
+                const peer = devices.find((d) => d.id === peerId);
+                return (
+                  <button
+                    key={conn.id}
+                    onClick={() => selectDevice(peerId)}
+                    className="w-full flex items-center justify-between py-1 border-b border-nd-border last:border-0 hover:bg-nd-surface-raised transition-colors text-left"
+                  >
+                    <span className="font-mono text-caption text-nd-text-primary">{peer?.hostname || peer?.ip || peerId.slice(0, 12)}</span>
+                    <span className="font-mono text-label uppercase text-nd-text-disabled">{conn.connection_type}</span>
+                  </button>
+                );
+              })}
             </div>
           </Section>
         )}
@@ -144,21 +164,21 @@ export default function DeviceInspector() {
           {deps.depends_on.length > 0 && (
             <div className="space-y-1">
               {deps.depends_on.map((dep) => (
-                <div key={dep.id} className="text-xs text-text-secondary">
-                  <span className="text-text-muted mr-1">\u2191</span>
+                <div key={dep.id} className="font-mono text-caption text-nd-text-secondary">
+                  <span className="text-nd-text-disabled mr-1">{'\u2191'}</span>
                   Depends on: {dep.target_id.slice(0, 8)} ({dep.dependency_type})
                 </div>
               ))}
             </div>
           )}
           {deps.depended_by.length > 0 && (
-            <div className="text-xs text-text-secondary mt-1">
-              <span className="text-text-muted mr-1">\u2193</span>
+            <div className="font-mono text-caption text-nd-text-secondary mt-1">
+              <span className="text-nd-text-disabled mr-1">{'\u2193'}</span>
               {deps.depended_by.length} devices depend on this
             </div>
           )}
           {deps.depends_on.length === 0 && deps.depended_by.length === 0 && (
-            <div className="text-xs text-text-muted">No dependencies tracked</div>
+            <div className="font-mono text-caption text-nd-text-disabled">No dependencies tracked</div>
           )}
         </Section>
 
@@ -166,16 +186,16 @@ export default function DeviceInspector() {
         <div className="flex flex-wrap gap-2 pt-2">
           <button
             onClick={handleSimulate}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-risk-critical/10 text-risk-critical text-xs font-medium hover:bg-risk-critical/20 transition-colors"
+            className="flex items-center gap-1.5 px-4 py-1.5 rounded-nd-pill border border-nd-accent font-mono text-label uppercase tracking-[0.06em] text-nd-accent hover:bg-nd-accent/10 transition-colors"
           >
-            <Zap size={12} />
+            <Zap size={12} strokeWidth={1.5} />
             Simulate Failure
           </button>
           <button
             onClick={() => setCurrentView('topology')}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-tertiary text-text-secondary text-xs font-medium hover:text-text-primary transition-colors"
+            className="flex items-center gap-1.5 px-4 py-1.5 rounded-nd-pill border border-nd-border-visible font-mono text-label uppercase tracking-[0.06em] text-nd-text-secondary hover:text-nd-text-primary hover:border-nd-text-disabled transition-colors"
           >
-            <Route size={12} />
+            <Route size={12} strokeWidth={1.5} />
             Show Paths
           </button>
         </div>
@@ -187,7 +207,7 @@ export default function DeviceInspector() {
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div>
-      <div className="text-[10px] text-text-muted uppercase tracking-wider mb-2 border-b border-bg-tertiary pb-1">
+      <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled mb-2 border-b border-nd-border pb-1">
         {title}
       </div>
       {children}
@@ -197,9 +217,9 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 function InfoRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex justify-between py-0.5 text-xs">
-      <span className="text-text-muted">{label}</span>
-      <span className="text-text-secondary font-mono text-right max-w-[200px] truncate">{value}</span>
+    <div className="flex justify-between py-0.5">
+      <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">{label}</span>
+      <span className="font-mono text-caption text-nd-text-primary text-right max-w-[200px] truncate">{value}</span>
     </div>
   );
 }

--- a/network-topology-mapper/frontend/src/components/panels/ResilienceReport.tsx
+++ b/network-topology-mapper/frontend/src/components/panels/ResilienceReport.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useState } from 'react';
-import { FileText, RefreshCw, Download } from 'lucide-react';
+import { RefreshCw } from 'lucide-react';
 import { fetchResilienceReport } from '../../lib/api';
 import { getRiskColor, getRiskLabel } from '../../lib/graph-utils';
 import type { ResilienceReport as ReportType } from '../../types/topology';
-import RiskScore from '../shared/RiskScore';
 
 export default function ResilienceReport() {
   const [report, setReport] = useState<ReportType | null>(null);
@@ -27,21 +26,19 @@ export default function ResilienceReport() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-full text-text-muted">
-        <RefreshCw size={20} className="animate-spin mr-2" />
-        Generating report...
+      <div className="flex items-center justify-center h-full">
+        <span className="font-mono text-caption text-nd-text-disabled">[GENERATING REPORT...]</span>
       </div>
     );
   }
 
   if (!report) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-text-muted gap-4">
-        <FileText size={48} className="text-text-muted/30" />
-        <p className="text-sm">No report available</p>
+      <div className="flex flex-col items-center justify-center h-full gap-6">
+        <div className="font-mono text-caption text-nd-text-disabled">[NO REPORT AVAILABLE]</div>
         <button
           onClick={loadReport}
-          className="px-4 py-2 rounded-lg bg-node-switch text-white text-sm hover:bg-node-switch/90 transition-colors"
+          className="px-5 py-2 rounded-nd-pill bg-black text-white font-mono text-label uppercase tracking-[0.06em] hover:opacity-90 transition-opacity"
         >
           Generate Report
         </button>
@@ -50,6 +47,8 @@ export default function ResilienceReport() {
   }
 
   const riskColor = getRiskColor(report.score / 10);
+  const scoreSegments = 10;
+  const scoreFilled = Math.round((report.score / report.max_score) * scoreSegments);
 
   return (
     <div className="h-full overflow-y-auto p-6">
@@ -57,101 +56,98 @@ export default function ResilienceReport() {
         {/* Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-xl font-bold text-text-primary">Network Resilience Assessment</h1>
-            <p className="text-xs text-text-muted mt-1">
-              {report.generated ? 'AI-generated' : 'Auto-generated'} report
+            <h1 className="font-display text-display-md font-bold text-black">Resilience</h1>
+            <p className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled mt-1">
+              {report.generated ? 'AI-generated' : 'Auto-generated'} assessment
             </p>
           </div>
-          <div className="flex gap-2">
-            <button
-              onClick={loadReport}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-secondary border border-bg-tertiary text-xs text-text-secondary hover:text-text-primary transition-colors"
-            >
-              <RefreshCw size={12} />
-              Regenerate
-            </button>
-          </div>
+          <button
+            onClick={loadReport}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-nd-pill border border-nd-border-visible font-mono text-label uppercase tracking-[0.06em] text-nd-text-secondary hover:text-nd-text-primary hover:border-nd-text-disabled transition-colors"
+          >
+            <RefreshCw size={12} strokeWidth={1.5} />
+            Regenerate
+          </button>
         </div>
 
-        {/* Score */}
-        <div className="bg-bg-secondary rounded-xl p-6 border border-bg-tertiary">
-          <div className="text-sm text-text-muted mb-3">Overall Score</div>
-          <div className="flex items-end gap-3 mb-3">
-            <span className="text-4xl font-bold" style={{ color: riskColor }}>
+        {/* Score hero */}
+        <div className="bg-nd-surface rounded-nd-card p-6 border border-nd-border">
+          <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled mb-3">Overall Score</div>
+          <div className="flex items-baseline gap-2 mb-3">
+            <span className="font-display text-display-xl font-bold" style={{ color: riskColor }}>
               {report.score}
             </span>
-            <span className="text-text-muted text-lg mb-1">/ {report.max_score}</span>
+            <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">/ {report.max_score}</span>
             <span
-              className="text-sm font-medium mb-1.5 ml-2"
+              className="font-mono text-label uppercase tracking-[0.08em] ml-2"
               style={{ color: riskColor }}
             >
-              ({getRiskLabel(report.score / 10)} Risk)
+              {getRiskLabel(report.score / 10)} Risk
             </span>
           </div>
-          <div className="h-3 bg-bg-tertiary rounded-full overflow-hidden">
-            <div
-              className="h-full rounded-full transition-all duration-700"
-              style={{
-                width: `${(report.score / report.max_score) * 100}%`,
-                backgroundColor: riskColor,
-              }}
-            />
+          {/* Segmented bar */}
+          <div className="h-3 flex gap-[2px]">
+            {Array.from({ length: scoreSegments }).map((_, i) => (
+              <div
+                key={i}
+                className="flex-1 h-full"
+                style={{ backgroundColor: i < scoreFilled ? riskColor : '#E8E8E8' }}
+              />
+            ))}
           </div>
         </div>
 
-        {/* Stats */}
+        {/* Stats row */}
         <div className="grid grid-cols-3 gap-4">
-          <div className="bg-bg-secondary rounded-lg p-4 border border-bg-tertiary">
-            <div className="text-2xl font-bold text-text-primary">{report.stats.total_devices}</div>
-            <div className="text-xs text-text-muted">Devices</div>
-          </div>
-          <div className="bg-bg-secondary rounded-lg p-4 border border-bg-tertiary">
-            <div className="text-2xl font-bold text-text-primary">{report.stats.total_connections}</div>
-            <div className="text-xs text-text-muted">Connections</div>
-          </div>
-          <div className="bg-bg-secondary rounded-lg p-4 border border-bg-tertiary">
-            <div className="text-2xl font-bold text-risk-critical">{report.spofs.length}</div>
-            <div className="text-xs text-text-muted">SPOFs</div>
-          </div>
+          {[
+            { value: report.stats.total_devices, label: 'Devices', color: '#1A1A1A' },
+            { value: report.stats.total_connections, label: 'Connections', color: '#1A1A1A' },
+            { value: report.spofs.length, label: 'SPOFs', color: report.spofs.length > 0 ? '#D71921' : '#1A1A1A' },
+          ].map((stat) => (
+            <div key={stat.label} className="bg-nd-surface rounded-nd-compact p-4 border border-nd-border">
+              <div className="font-mono text-heading font-bold" style={{ color: stat.color }}>{stat.value}</div>
+              <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled mt-0.5">{stat.label}</div>
+            </div>
+          ))}
         </div>
 
         {/* Report body */}
-        <div className="bg-bg-secondary rounded-xl p-6 border border-bg-tertiary">
-          <div className="prose prose-invert prose-sm max-w-none">
+        <div className="bg-nd-surface rounded-nd-card p-6 border border-nd-border">
+          <div className="space-y-2">
             {report.report.split('\n').map((line, i) => {
               if (line.startsWith('# ')) {
-                return <h2 key={i} className="text-lg font-bold text-text-primary mt-4 mb-2">{line.slice(2)}</h2>;
+                return <h2 key={i} className="font-sans text-subheading font-medium text-nd-text-display mt-4 mb-2">{line.slice(2)}</h2>;
               }
               if (line.startsWith('## ')) {
-                return <h3 key={i} className="text-base font-semibold text-text-primary mt-4 mb-2">{line.slice(3)}</h3>;
+                return <h3 key={i} className="font-sans text-body font-medium text-nd-text-display mt-4 mb-2">{line.slice(3)}</h3>;
               }
               if (line.match(/^\d+\./)) {
-                return <p key={i} className="text-sm text-text-secondary mb-1 pl-4">{line}</p>;
+                return <p key={i} className="text-body-sm text-nd-text-secondary mb-1 pl-4">{line}</p>;
               }
               if (line.startsWith('**') && line.endsWith('**')) {
-                return <p key={i} className="text-sm font-semibold text-text-primary mt-2">{line.replace(/\*\*/g, '')}</p>;
+                return <p key={i} className="text-body-sm font-medium text-nd-text-primary mt-2">{line.replace(/\*\*/g, '')}</p>;
               }
               if (line.trim() === '') {
                 return <br key={i} />;
               }
-              return <p key={i} className="text-sm text-text-secondary mb-1">{line}</p>;
+              return <p key={i} className="text-body-sm text-nd-text-secondary mb-1">{line}</p>;
             })}
           </div>
         </div>
 
         {/* SPOFs table */}
         {report.spofs.length > 0 && (
-          <div className="bg-bg-secondary rounded-xl p-6 border border-bg-tertiary">
-            <h3 className="text-sm font-semibold text-text-primary mb-3">Single Points of Failure</h3>
-            <div className="space-y-2">
+          <div className="bg-nd-surface rounded-nd-card p-6 border border-nd-border">
+            <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary mb-3">Single Points of Failure</div>
+            <div className="space-y-0">
               {report.spofs.map((spof, i) => (
-                <div key={i} className="flex items-center justify-between bg-bg-tertiary rounded-lg px-3 py-2">
+                <div key={i} className="flex items-center justify-between py-2 border-b border-nd-border last:border-0">
                   <div>
-                    <span className="text-xs font-medium text-text-primary">{spof.hostname}</span>
-                    <span className="text-[10px] text-text-muted ml-2 capitalize">({spof.device_type})</span>
+                    <span className="font-sans text-body-sm font-medium text-nd-text-primary">{spof.hostname}</span>
+                    <span className="font-mono text-label uppercase text-nd-text-disabled ml-2">({spof.device_type})</span>
                   </div>
-                  <span className="text-xs text-risk-critical">
-                    Impact: {spof.impact} devices
+                  <span className="font-mono text-caption text-nd-accent font-bold">
+                    Impact: {spof.impact}
                   </span>
                 </div>
               ))}

--- a/network-topology-mapper/frontend/src/components/panels/ScanStatus.tsx
+++ b/network-topology-mapper/frontend/src/components/panels/ScanStatus.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Play, Square, RefreshCw, Clock, CheckCircle, XCircle, AlertTriangle, Wifi, ChevronDown, ChevronUp, Trash2, Terminal } from 'lucide-react';
+import { Play, Square, RefreshCw, Clock, ChevronDown, ChevronUp, Trash2, Terminal } from 'lucide-react';
 import { fetchScans, triggerScan, cancelScan, fetchSettings, clearTopology } from '../../lib/api';
 import { formatTimeAgo } from '../../lib/graph-utils';
 import type { Scan, ScanProgress } from '../../types/topology';
@@ -87,72 +87,74 @@ export default function ScanStatus() {
     }
   };
 
-  const getStatusIcon = (status: string) => {
+  const getStatusLabel = (status: string) => {
     switch (status) {
-      case 'completed': return <CheckCircle size={14} className="text-status-online" />;
-      case 'running': return <RefreshCw size={14} className="text-node-switch animate-spin" />;
-      case 'failed': return <XCircle size={14} className="text-risk-critical" />;
-      case 'cancelled': return <AlertTriangle size={14} className="text-risk-medium" />;
-      default: return <Clock size={14} className="text-text-muted" />;
+      case 'completed': return <span className="font-mono text-label uppercase text-nd-success">[DONE]</span>;
+      case 'running': return <span className="font-mono text-label uppercase text-nd-text-primary">[RUNNING]</span>;
+      case 'failed': return <span className="font-mono text-label uppercase text-nd-accent">[FAILED]</span>;
+      case 'cancelled': return <span className="font-mono text-label uppercase text-nd-warning">[CANCELLED]</span>;
+      default: return <span className="font-mono text-label uppercase text-nd-text-disabled">[PENDING]</span>;
     }
   };
 
-  const friendlySubnet = detectedSubnet
-    ? detectedSubnet.replace('/24', ' network').replace('/16', ' network')
-    : '';
+  const segments = 20;
+  const filledSegments = progress ? Math.round((progress.percent / 100) * segments) : 0;
 
   return (
     <div className="h-full overflow-y-auto p-6">
       <div className="max-w-2xl mx-auto space-y-6">
-        <h1 className="text-xl font-bold text-text-primary">Network Scanner</h1>
+        <h1 className="font-display text-display-md font-bold text-black">Scanner</h1>
 
         {/* Scan My Network — primary action */}
-        <div className="bg-bg-secondary rounded-xl p-5 border border-bg-tertiary space-y-4">
-          <div className="text-sm font-semibold text-text-primary">Scan Your Network</div>
+        <div className="bg-nd-surface rounded-nd-card p-5 border border-nd-border space-y-4">
+          <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Scan Your Network</div>
 
           {detectedSubnet ? (
-            <div className="flex items-center gap-3 bg-bg-tertiary/50 rounded-lg px-4 py-3">
-              <Wifi size={18} className="text-node-switch shrink-0" />
+            <div className="flex items-center gap-3 bg-nd-surface-raised rounded-nd-compact px-4 py-3">
               <div className="flex-1 min-w-0">
-                <div className="text-xs text-text-secondary">Detected network</div>
-                <div className="text-sm text-text-primary font-medium truncate">{detectedSubnet}</div>
+                <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">Detected Network</div>
+                <div className="font-mono text-body-sm text-nd-text-display font-bold truncate mt-0.5">{detectedSubnet}</div>
               </div>
               <button
                 onClick={() => handleStartScan(detectedSubnet)}
-                className="flex items-center gap-1.5 px-5 py-2 rounded-lg bg-node-switch text-white text-sm font-medium hover:bg-node-switch/90 transition-colors shrink-0"
+                className="flex items-center gap-1.5 px-5 py-2 rounded-nd-pill bg-black text-white font-mono text-label uppercase tracking-[0.06em] hover:opacity-90 transition-opacity shrink-0"
               >
-                <Play size={14} />
-                Scan My Network
+                <Play size={14} strokeWidth={1.5} />
+                SCAN
               </button>
             </div>
           ) : (
-            <div className="text-xs text-text-muted">Detecting your network...</div>
+            <div className="font-mono text-caption text-nd-text-disabled">[DETECTING...]</div>
           )}
 
           {/* Intensity */}
           <div className="flex items-center gap-4">
-            <label className="text-xs text-text-muted">Scan intensity:</label>
-            {(['light', 'normal', 'deep'] as const).map((level) => (
-              <label key={level} className="flex items-center gap-1.5 cursor-pointer">
-                <input
-                  type="radio"
-                  checked={scanIntensity === level}
-                  onChange={() => setScanIntensity(level)}
-                  className="accent-node-switch"
-                />
-                <span className="text-xs text-text-secondary capitalize">{level}</span>
-              </label>
-            ))}
+            <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">Intensity:</span>
+            <div className="flex border border-nd-border-visible rounded-nd-pill overflow-hidden">
+              {(['light', 'normal', 'deep'] as const).map((level) => (
+                <button
+                  key={level}
+                  onClick={() => setScanIntensity(level)}
+                  className={`px-3 py-1 font-mono text-label uppercase tracking-[0.08em] transition-colors ${
+                    scanIntensity === level
+                      ? 'bg-black text-white'
+                      : 'text-nd-text-secondary hover:text-nd-text-primary'
+                  }`}
+                >
+                  {level}
+                </button>
+              ))}
+            </div>
           </div>
 
-          {/* Advanced — manual target entry */}
+          {/* Advanced */}
           <div>
             <button
               onClick={() => setShowAdvanced(!showAdvanced)}
-              className="flex items-center gap-1 text-xs text-text-muted hover:text-text-secondary transition-colors"
+              className="flex items-center gap-1 font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled hover:text-nd-text-secondary transition-colors"
             >
-              {showAdvanced ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
-              Advanced: scan a different network
+              {showAdvanced ? <ChevronUp size={12} strokeWidth={1.5} /> : <ChevronDown size={12} strokeWidth={1.5} />}
+              Custom target
             </button>
             {showAdvanced && (
               <div className="flex items-center gap-3 mt-2">
@@ -160,13 +162,13 @@ export default function ScanStatus() {
                   value={scanTarget}
                   onChange={(e) => setScanTarget(e.target.value)}
                   placeholder="e.g. 192.168.1.0/24"
-                  className="flex-1 bg-bg-tertiary border border-bg-tertiary rounded-lg px-3 py-1.5 text-xs text-text-primary outline-none focus:border-node-switch transition-colors"
+                  className="flex-1 bg-transparent border-b border-nd-border-visible px-1 py-1.5 font-mono text-body-sm text-nd-text-primary outline-none focus:border-nd-text-primary transition-colors"
                 />
                 <button
                   onClick={() => handleStartScan()}
-                  className="flex items-center gap-1.5 px-4 py-1.5 rounded-lg bg-bg-tertiary text-text-primary text-xs font-medium hover:bg-bg-tertiary/70 border border-bg-tertiary transition-colors"
+                  className="flex items-center gap-1.5 px-4 py-1.5 rounded-nd-pill border border-nd-border-visible font-mono text-label uppercase tracking-[0.06em] text-nd-text-primary hover:border-nd-text-primary transition-colors"
                 >
-                  <Play size={12} />
+                  <Play size={12} strokeWidth={1.5} />
                   Scan
                 </button>
               </div>
@@ -176,61 +178,55 @@ export default function ScanStatus() {
 
         {/* Current progress */}
         {progress && (
-          <div className={`bg-bg-secondary rounded-xl p-5 space-y-3 border ${progress.percent >= 100 ? 'border-status-online/30' : 'border-node-switch/30'}`}>
+          <div className={`bg-nd-surface rounded-nd-card p-5 space-y-3 border ${progress.percent >= 100 ? 'border-nd-success' : 'border-nd-border'}`}>
             <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                {progress.percent >= 100 ? (
-                  <>
-                    <CheckCircle size={14} className="text-status-online" />
-                    <span className="text-sm font-semibold text-text-primary">Scan Complete</span>
-                  </>
-                ) : (
-                  <>
-                    <RefreshCw size={14} className="text-node-switch animate-spin" />
-                    <span className="text-sm font-semibold text-text-primary">Scan In Progress</span>
-                  </>
-                )}
-              </div>
+              <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-display">
+                {progress.percent >= 100 ? '[SCAN COMPLETE]' : '[SCANNING...]'}
+              </span>
               {progress.percent >= 100 ? (
                 <button
                   onClick={() => { setProgress(null); loadScans(); }}
-                  className="text-xs text-text-muted hover:text-text-primary transition-colors"
+                  className="font-mono text-label uppercase tracking-[0.06em] text-nd-text-disabled hover:text-nd-text-primary transition-colors"
                 >
                   Dismiss
                 </button>
               ) : (
                 <button
                   onClick={handleCancelScan}
-                  className="flex items-center gap-1.5 px-3 py-1 rounded-lg text-risk-critical border border-risk-critical/30 text-xs font-medium hover:bg-risk-critical/10 transition-colors"
+                  className="flex items-center gap-1.5 px-3 py-1 rounded-nd-pill border border-nd-accent font-mono text-label uppercase tracking-[0.06em] text-nd-accent hover:bg-nd-accent/10 transition-colors"
                 >
-                  <Square size={10} />
+                  <Square size={10} strokeWidth={1.5} />
                   Cancel
                 </button>
               )}
             </div>
 
-            <div className="flex justify-between text-xs mb-1">
-              <span className="text-text-secondary capitalize">{progress.phase.replace(/_/g, ' ')}</span>
-              <span className="text-text-muted">{progress.percent}% &middot; {progress.devices_found} devices</span>
+            <div className="flex justify-between font-mono text-caption mb-1">
+              <span className="text-nd-text-secondary uppercase">{progress.phase.replace(/_/g, ' ')}</span>
+              <span className="text-nd-text-disabled">{progress.percent}% &middot; {progress.devices_found} devices</span>
             </div>
-            <div className="h-2 bg-bg-tertiary rounded-full overflow-hidden">
-              <div
-                className={`h-full rounded-full transition-all duration-300 ${progress.percent >= 100 ? 'bg-status-online' : 'bg-node-switch'}`}
-                style={{ width: `${progress.percent}%` }}
-              />
+            {/* Segmented progress bar */}
+            <div className="h-2 flex gap-[2px]">
+              {Array.from({ length: segments }).map((_, i) => (
+                <div
+                  key={i}
+                  className="flex-1 h-full"
+                  style={{ backgroundColor: i < filledSegments ? (progress.percent >= 100 ? '#4A9E5C' : '#1A1A1A') : '#E8E8E8' }}
+                />
+              ))}
             </div>
 
             {/* Live log */}
             {progress.log_messages && progress.log_messages.length > 0 && (
               <div className="mt-2">
                 <div className="flex items-center gap-1.5 mb-1.5">
-                  <Terminal size={12} className="text-text-muted" />
-                  <span className="text-xs text-text-muted">Scan log</span>
+                  <Terminal size={12} strokeWidth={1.5} className="text-nd-text-disabled" />
+                  <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">Scan Log</span>
                 </div>
-                <div className="bg-bg-primary rounded-lg p-3 max-h-40 overflow-y-auto font-mono text-xs border border-bg-tertiary">
+                <div className="bg-nd-black rounded-nd-compact p-3 max-h-40 overflow-y-auto font-mono text-caption border border-nd-border">
                   {progress.log_messages.map((msg, i) => (
-                    <div key={i} className="text-text-secondary py-0.5">
-                      <span className="text-text-muted select-none">&gt; </span>{msg}
+                    <div key={i} className="text-nd-text-secondary py-0.5">
+                      <span className="text-nd-text-disabled select-none">&gt; </span>{msg}
                     </div>
                   ))}
                   <div ref={logEndRef} />
@@ -241,46 +237,46 @@ export default function ScanStatus() {
         )}
 
         {/* Scheduled scans */}
-        <div className="bg-bg-secondary rounded-xl p-5 border border-bg-tertiary">
-          <div className="text-sm font-semibold text-text-primary mb-3">Scheduled Scans</div>
+        <div className="bg-nd-surface rounded-nd-card p-5 border border-nd-border">
+          <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary mb-3">Scheduled Scans</div>
           <div className="space-y-2">
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-text-primary">Full scan</span>
-              <span className="text-text-muted">Every 6 hours</span>
-            </div>
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-text-primary">Passive capture</span>
-              <span className="text-status-online">Continuous</span>
-            </div>
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-text-primary">SNMP poll</span>
-              <span className="text-text-muted">Every 30 min</span>
-            </div>
+            {[
+              { label: 'Full scan', value: 'Every 6 hours' },
+              { label: 'Passive capture', value: 'Continuous', active: true },
+              { label: 'SNMP poll', value: 'Every 30 min' },
+            ].map((item) => (
+              <div key={item.label} className="flex items-center justify-between py-1 border-b border-nd-border last:border-0">
+                <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">{item.label}</span>
+                <span className={`font-mono text-caption ${item.active ? 'text-nd-success' : 'text-nd-text-secondary'}`}>
+                  {item.value}
+                </span>
+              </div>
+            ))}
           </div>
         </div>
 
         {/* Scan history */}
-        <div className="bg-bg-secondary rounded-xl p-5 border border-bg-tertiary">
+        <div className="bg-nd-surface rounded-nd-card p-5 border border-nd-border">
           <div className="flex items-center justify-between mb-3">
-            <div className="text-sm font-semibold text-text-primary">Recent Scans</div>
-            <button onClick={loadScans} className="text-text-muted hover:text-text-primary transition-colors">
-              <RefreshCw size={14} />
+            <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Recent Scans</span>
+            <button onClick={loadScans} className="text-nd-text-disabled hover:text-nd-text-primary transition-colors">
+              <RefreshCw size={14} strokeWidth={1.5} />
             </button>
           </div>
 
-          {loading && <div className="text-xs text-text-muted">Loading...</div>}
+          {loading && <div className="font-mono text-caption text-nd-text-disabled">[LOADING...]</div>}
 
-          <div className="space-y-2">
+          <div className="space-y-1">
             {scans.map((scan) => (
-              <div key={scan.id} className="flex items-center gap-3 text-xs bg-bg-tertiary/50 rounded-lg px-3 py-2">
-                {getStatusIcon(scan.status)}
+              <div key={scan.id} className="flex items-center gap-3 py-2 border-b border-nd-border last:border-0">
+                {getStatusLabel(scan.status)}
                 <div className="flex-1">
-                  <div className="text-text-primary capitalize">{scan.scan_type} scan</div>
-                  <div className="text-text-muted">{scan.target_range}</div>
+                  <div className="font-mono text-caption text-nd-text-primary uppercase">{scan.scan_type} scan</div>
+                  <div className="font-mono text-label text-nd-text-disabled">{scan.target_range}</div>
                 </div>
                 <div className="text-right">
-                  <div className="text-text-secondary">{scan.devices_found} devices</div>
-                  <div className="text-text-muted">{formatTimeAgo(scan.started_at || '')}</div>
+                  <div className="font-mono text-caption text-nd-text-secondary">{scan.devices_found} devices</div>
+                  <div className="font-mono text-label text-nd-text-disabled">{formatTimeAgo(scan.started_at || '')}</div>
                 </div>
               </div>
             ))}
@@ -288,32 +284,32 @@ export default function ScanStatus() {
         </div>
 
         {/* Clear database */}
-        <div className="bg-bg-secondary rounded-xl p-5 border border-risk-critical/20">
+        <div className="bg-nd-surface rounded-nd-card p-5 border border-nd-accent/30">
           <div className="flex items-center justify-between">
             <div>
-              <div className="text-sm font-semibold text-text-primary">Clear Device Database</div>
-              <div className="text-xs text-text-muted mt-0.5">Remove all discovered devices, connections, and dependencies.</div>
+              <div className="font-sans text-body-sm font-medium text-nd-text-primary">Clear Device Database</div>
+              <div className="font-mono text-label uppercase tracking-[0.06em] text-nd-text-disabled mt-0.5">Remove all discovered data</div>
             </div>
             {!showClearConfirm ? (
               <button
                 onClick={() => setShowClearConfirm(true)}
-                className="flex items-center gap-1.5 px-4 py-1.5 rounded-lg text-risk-critical border border-risk-critical/30 text-xs font-medium hover:bg-risk-critical/10 transition-colors"
+                className="flex items-center gap-1.5 px-4 py-1.5 rounded-nd-pill border border-nd-accent font-mono text-label uppercase tracking-[0.06em] text-nd-accent hover:bg-nd-accent/10 transition-colors"
               >
-                <Trash2 size={12} />
+                <Trash2 size={12} strokeWidth={1.5} />
                 Clear All
               </button>
             ) : (
               <div className="flex items-center gap-2">
-                <span className="text-xs text-risk-critical">Are you sure?</span>
+                <span className="font-mono text-caption text-nd-accent">Are you sure?</span>
                 <button
                   onClick={handleClearDatabase}
-                  className="px-3 py-1.5 rounded-lg bg-risk-critical text-white text-xs font-medium hover:bg-risk-critical/90 transition-colors"
+                  className="px-3 py-1.5 rounded-nd-pill bg-nd-accent text-white font-mono text-label uppercase tracking-[0.06em] hover:opacity-90 transition-opacity"
                 >
-                  Yes, clear everything
+                  Yes
                 </button>
                 <button
                   onClick={() => setShowClearConfirm(false)}
-                  className="px-3 py-1.5 rounded-lg bg-bg-tertiary text-text-secondary text-xs font-medium hover:bg-bg-tertiary/70 transition-colors"
+                  className="px-3 py-1.5 rounded-nd-pill border border-nd-border-visible font-mono text-label uppercase tracking-[0.06em] text-nd-text-secondary hover:text-nd-text-primary transition-colors"
                 >
                   Cancel
                 </button>

--- a/network-topology-mapper/frontend/src/components/panels/SimulationPanel.tsx
+++ b/network-topology-mapper/frontend/src/components/panels/SimulationPanel.tsx
@@ -1,8 +1,7 @@
-import { X, Play, Trash2, Plus, Zap, AlertTriangle, CheckCircle, XCircle } from 'lucide-react';
+import { X, Play, Trash2, Plus } from 'lucide-react';
 import { useTopologyStore } from '../../stores/topologyStore';
 import { useSimulation } from '../../hooks/useSimulation';
 import DeviceIcon from '../shared/DeviceIcon';
-import type { Device } from '../../types/topology';
 import { useState } from 'react';
 
 export default function SimulationPanel() {
@@ -28,34 +27,38 @@ export default function SimulationPanel() {
     )
     .slice(0, 20);
 
+  const blastSegments = 20;
+  const blastFilled = simulationResult ? Math.round((simulationResult.blast_radius_pct / 100) * blastSegments) : 0;
+
   return (
-    <div className="w-[380px] h-full bg-bg-secondary border-l border-bg-tertiary flex flex-col animate-slide-in-right">
-      <div className="sticky top-0 bg-bg-secondary border-b border-bg-tertiary px-4 py-3 flex items-center justify-between z-10 flex-shrink-0">
-        <span className="text-sm font-semibold text-text-primary">Failure Simulation</span>
+    <div className="w-[380px] flex-shrink-0 h-full bg-nd-surface border-l border-nd-border flex flex-col animate-fade-in">
+      {/* Header */}
+      <div className="sticky top-0 bg-nd-surface border-b border-nd-border px-4 py-3 flex items-center justify-between z-10 flex-shrink-0">
+        <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Failure Simulation</span>
         <button
           onClick={() => setRightPanelContent(null)}
-          className="text-text-muted hover:text-text-primary transition-colors"
+          className="text-nd-text-disabled hover:text-nd-text-primary transition-colors"
         >
-          <X size={16} />
+          <X size={16} strokeWidth={1.5} />
         </button>
       </div>
 
       <div className="flex-1 overflow-y-auto p-4 space-y-4">
         {/* Target selection */}
         <div>
-          <div className="text-xs text-text-muted mb-2">Select targets to simulate failure:</div>
+          <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled mb-2">Targets</div>
           <div className="space-y-1.5">
             {targetDevices.map((d) => (
-              <div key={d.id} className="flex items-center justify-between bg-bg-tertiary rounded-lg px-3 py-2">
+              <div key={d.id} className="flex items-center justify-between bg-nd-surface-raised border border-nd-border rounded-nd-compact px-3 py-2">
                 <div className="flex items-center gap-2">
                   <DeviceIcon type={d.device_type} size={14} />
-                  <span className="text-xs text-text-primary">{d.hostname || d.ip}</span>
+                  <span className="font-mono text-caption text-nd-text-primary">{d.hostname || d.ip}</span>
                 </div>
                 <button
                   onClick={() => removeTarget('nodes', d.id)}
-                  className="text-text-muted hover:text-risk-critical transition-colors"
+                  className="text-nd-text-disabled hover:text-nd-accent transition-colors"
                 >
-                  <X size={14} />
+                  <X size={14} strokeWidth={1.5} />
                 </button>
               </div>
             ))}
@@ -64,20 +67,20 @@ export default function SimulationPanel() {
           <div className="relative mt-2">
             <button
               onClick={() => setShowDevicePicker(!showDevicePicker)}
-              className="flex items-center gap-1.5 text-xs text-node-switch hover:text-node-switch/80 transition-colors"
+              className="flex items-center gap-1.5 font-mono text-label uppercase tracking-[0.06em] text-nd-interactive hover:opacity-80 transition-opacity"
             >
-              <Plus size={12} />
-              Add device
+              <Plus size={12} strokeWidth={1.5} />
+              Add Device
             </button>
 
             {showDevicePicker && (
-              <div className="absolute top-full left-0 mt-1 w-full bg-bg-primary border border-bg-tertiary rounded-lg shadow-xl z-20 max-h-60 overflow-y-auto">
+              <div className="absolute top-full left-0 mt-1 w-full bg-nd-surface border border-nd-border-visible rounded-nd-compact z-20 max-h-60 overflow-y-auto">
                 <input
                   autoFocus
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
                   placeholder="Search devices..."
-                  className="w-full px-3 py-2 text-xs bg-transparent border-b border-bg-tertiary outline-none text-text-primary"
+                  className="w-full px-3 py-2 font-mono text-caption bg-transparent border-b border-nd-border outline-none text-nd-text-primary placeholder:text-nd-text-disabled"
                 />
                 {filteredDevices.map((d) => (
                   <button
@@ -87,11 +90,11 @@ export default function SimulationPanel() {
                       setShowDevicePicker(false);
                       setSearch('');
                     }}
-                    className="w-full flex items-center gap-2 px-3 py-2 text-xs text-left hover:bg-bg-tertiary transition-colors"
+                    className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-nd-surface-raised transition-colors"
                   >
                     <DeviceIcon type={d.device_type} size={12} />
-                    <span className="text-text-primary">{d.hostname || d.ip}</span>
-                    <span className="text-text-muted ml-auto">{d.ip}</span>
+                    <span className="font-mono text-caption text-nd-text-primary">{d.hostname || d.ip}</span>
+                    <span className="font-mono text-label text-nd-text-disabled ml-auto">{d.ip}</span>
                   </button>
                 ))}
               </div>
@@ -99,74 +102,80 @@ export default function SimulationPanel() {
           </div>
         </div>
 
-        {/* Run button */}
+        {/* Action buttons */}
         <div className="flex gap-2">
           <button
             onClick={runSimulation}
             disabled={loading || simulationTargets.nodes.length === 0}
-            className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-risk-critical text-white text-xs font-medium hover:bg-risk-critical/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="flex items-center gap-1.5 px-4 py-2 rounded-nd-pill bg-nd-accent text-white font-mono text-label uppercase tracking-[0.06em] hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
           >
-            <Play size={12} />
-            {loading ? 'Running...' : 'Run Simulation'}
+            <Play size={12} strokeWidth={1.5} />
+            {loading ? 'Running...' : 'Simulate'}
           </button>
           {(simulationActive || simulationTargets.nodes.length > 0) && (
             <button
               onClick={clearSimulation}
-              className="flex items-center gap-1.5 px-3 py-2 rounded-lg bg-bg-tertiary text-text-secondary text-xs hover:text-text-primary transition-colors"
+              className="flex items-center gap-1.5 px-3 py-2 rounded-nd-pill border border-nd-border-visible font-mono text-label uppercase tracking-[0.06em] text-nd-text-secondary hover:text-nd-text-primary transition-colors"
             >
-              <Trash2 size={12} />
+              <Trash2 size={12} strokeWidth={1.5} />
               Clear
             </button>
           )}
         </div>
 
         {error && (
-          <div className="text-xs text-risk-critical bg-risk-critical/10 rounded-lg px-3 py-2">
-            {error}
+          <div className="font-mono text-caption text-nd-accent border border-nd-accent/30 rounded-nd-compact px-3 py-2">
+            [ERROR] {error}
           </div>
         )}
 
         {/* Results */}
         {simulationResult && (
-          <div className="space-y-3 pt-2 border-t border-bg-tertiary">
-            <div className="text-xs font-semibold text-text-primary uppercase">Results</div>
+          <div className="space-y-4 pt-3 border-t border-nd-border">
+            <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Results</div>
 
+            {/* Blast radius */}
             <div>
-              <div className="flex justify-between text-xs mb-1">
-                <span className="text-text-secondary">Blast Radius</span>
-                <span className="text-risk-critical font-mono">
+              <div className="flex justify-between font-mono text-caption mb-1">
+                <span className="text-nd-text-disabled uppercase">Blast Radius</span>
+                <span className="text-nd-accent font-bold">
                   {simulationResult.blast_radius} devices ({simulationResult.blast_radius_pct}%)
                 </span>
               </div>
-              <div className="h-2 bg-bg-tertiary rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-risk-critical rounded-full transition-all duration-500"
-                  style={{ width: `${simulationResult.blast_radius_pct}%` }}
-                />
+              <div className="h-2 flex gap-[2px]">
+                {Array.from({ length: blastSegments }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="flex-1 h-full"
+                    style={{ backgroundColor: i < blastFilled ? '#D71921' : '#E8E8E8' }}
+                  />
+                ))}
               </div>
             </div>
 
-            <div className="grid grid-cols-2 gap-2 text-xs">
-              <div className="bg-bg-tertiary rounded-lg p-2">
-                <div className="text-text-muted">Disconnected</div>
-                <div className="text-lg font-bold text-risk-critical">
+            {/* Stats */}
+            <div className="grid grid-cols-2 gap-2">
+              <div className="bg-nd-surface-raised border border-nd-border rounded-nd-compact p-3">
+                <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">Disconnected</div>
+                <div className="font-mono text-heading font-bold text-nd-accent mt-1">
                   {simulationResult.disconnected_devices.length}
                 </div>
               </div>
-              <div className="bg-bg-tertiary rounded-lg p-2">
-                <div className="text-text-muted">Degraded</div>
-                <div className="text-lg font-bold text-risk-medium">
+              <div className="bg-nd-surface-raised border border-nd-border rounded-nd-compact p-3">
+                <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled">Degraded</div>
+                <div className="font-mono text-heading font-bold text-nd-warning mt-1">
                   {simulationResult.degraded_devices.length}
                 </div>
               </div>
             </div>
 
+            {/* Affected services */}
             {simulationResult.affected_services.length > 0 && (
               <div>
-                <div className="text-[10px] text-text-muted uppercase mb-1">Services Down</div>
+                <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled mb-1">Services Down</div>
                 <div className="flex flex-wrap gap-1">
                   {simulationResult.affected_services.map((svc) => (
-                    <span key={svc} className="text-[10px] px-2 py-0.5 rounded bg-risk-critical/10 text-risk-critical">
+                    <span key={svc} className="font-mono text-label uppercase tracking-[0.06em] px-2 py-0.5 rounded-nd-pill border border-nd-accent/30 text-nd-accent">
                       {svc}
                     </span>
                   ))}
@@ -174,34 +183,28 @@ export default function SimulationPanel() {
               </div>
             )}
 
-            <div className="text-xs">
-              <span className="text-text-muted">Risk delta: </span>
-              <span className="text-risk-critical font-mono">+{simulationResult.risk_delta}</span>
+            <div className="font-mono text-caption">
+              <span className="text-nd-text-disabled uppercase">Risk delta: </span>
+              <span className="text-nd-accent font-bold">+{simulationResult.risk_delta}</span>
             </div>
 
             {/* Affected devices */}
             {simulationResult.disconnected_devices.length > 0 && (
               <div>
-                <div className="text-[10px] text-text-muted uppercase mb-1">
-                  Affected Devices (top 10)
+                <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled mb-1">
+                  Affected Devices
                 </div>
                 <div className="space-y-1">
                   {simulationResult.disconnected_devices.slice(0, 10).map((d) => (
-                    <div key={d.id} className="flex items-center justify-between text-xs bg-bg-tertiary/50 rounded px-2 py-1">
-                      <span className="text-text-primary">{d.hostname || d.id.slice(0, 8)}</span>
-                      <span className="text-risk-critical flex items-center gap-1">
-                        <XCircle size={10} />
-                        {d.status}
-                      </span>
+                    <div key={d.id} className="flex items-center justify-between py-1 border-b border-nd-border last:border-0">
+                      <span className="font-mono text-caption text-nd-text-primary">{d.hostname || d.id.slice(0, 12)}</span>
+                      <span className="font-mono text-label uppercase text-nd-accent">{d.status}</span>
                     </div>
                   ))}
                   {simulationResult.degraded_devices.slice(0, 5).map((d) => (
-                    <div key={d.id} className="flex items-center justify-between text-xs bg-bg-tertiary/50 rounded px-2 py-1">
-                      <span className="text-text-primary">{d.hostname || d.id.slice(0, 8)}</span>
-                      <span className="text-risk-medium flex items-center gap-1">
-                        <AlertTriangle size={10} />
-                        {d.status}
-                      </span>
+                    <div key={d.id} className="flex items-center justify-between py-1 border-b border-nd-border last:border-0">
+                      <span className="font-mono text-caption text-nd-text-primary">{d.hostname || d.id.slice(0, 12)}</span>
+                      <span className="font-mono text-label uppercase text-nd-warning">{d.status}</span>
                     </div>
                   ))}
                 </div>
@@ -211,12 +214,12 @@ export default function SimulationPanel() {
             {/* Recommendations */}
             {simulationResult.recommendations.length > 0 && (
               <div>
-                <div className="text-[10px] text-text-muted uppercase mb-1">Recommendations</div>
+                <div className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-disabled mb-1">Recommendations</div>
                 <div className="space-y-2">
                   {simulationResult.recommendations.map((rec, i) => (
-                    <div key={i} className="text-xs bg-bg-tertiary rounded-lg p-2">
-                      <div className="text-text-primary">{i + 1}. {rec.action}</div>
-                      <div className="text-text-muted mt-0.5">{rec.impact}</div>
+                    <div key={i} className="border border-nd-border rounded-nd-compact p-2">
+                      <div className="font-sans text-caption text-nd-text-primary">{i + 1}. {rec.action}</div>
+                      <div className="font-mono text-label text-nd-text-disabled mt-0.5">{rec.impact}</div>
                     </div>
                   ))}
                 </div>
@@ -228,4 +231,3 @@ export default function SimulationPanel() {
     </div>
   );
 }
-

--- a/network-topology-mapper/frontend/src/components/shared/DeviceIcon.tsx
+++ b/network-topology-mapper/frontend/src/components/shared/DeviceIcon.tsx
@@ -2,7 +2,6 @@ import {
   Server, Router, Wifi, Shield, Monitor, Printer, Cpu, HelpCircle, Network,
 } from 'lucide-react';
 import type { DeviceType } from '../../types/topology';
-import { DEVICE_TYPE_COLORS } from '../../lib/graph-utils';
 
 const iconMap: Record<DeviceType, React.ElementType> = {
   router: Router,
@@ -24,7 +23,6 @@ interface Props {
 
 export default function DeviceIcon({ type, size = 18, className = '' }: Props) {
   const Icon = iconMap[type] || HelpCircle;
-  const color = DEVICE_TYPE_COLORS[type] || '#6B7280';
 
-  return <Icon size={size} color={color} className={className} />;
+  return <Icon size={size} strokeWidth={1.5} color="#1A1A1A" className={className} />;
 }

--- a/network-topology-mapper/frontend/src/components/shared/RiskScore.tsx
+++ b/network-topology-mapper/frontend/src/components/shared/RiskScore.tsx
@@ -11,28 +11,33 @@ export default function RiskScore({ score, showBar = true, showLabel = true, siz
   const color = getRiskColor(score);
   const label = getRiskLabel(score);
   const pct = Math.round(score * 100);
+  const segments = 10;
+  const filled = Math.round((pct / 100) * segments);
 
-  const textSize = size === 'sm' ? 'text-xs' : size === 'lg' ? 'text-lg' : 'text-sm';
+  const textSize = size === 'sm' ? 'text-caption' : size === 'lg' ? 'text-subheading' : 'text-body-sm';
   const barHeight = size === 'sm' ? 'h-1' : size === 'lg' ? 'h-3' : 'h-2';
 
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-center justify-between">
-        <span className={`${textSize} font-mono font-semibold`} style={{ color }}>
+        <span className={`${textSize} font-mono font-bold`} style={{ color }}>
           {score.toFixed(2)}
         </span>
         {showLabel && (
-          <span className={`${textSize} font-medium uppercase`} style={{ color }}>
+          <span className="font-mono text-label uppercase tracking-[0.08em]" style={{ color }}>
             {label}
           </span>
         )}
       </div>
       {showBar && (
-        <div className={`${barHeight} w-full rounded-full bg-bg-tertiary overflow-hidden`}>
-          <div
-            className={`${barHeight} rounded-full transition-all duration-500`}
-            style={{ width: `${pct}%`, backgroundColor: color }}
-          />
+        <div className={`${barHeight} w-full flex gap-[2px]`}>
+          {Array.from({ length: segments }).map((_, i) => (
+            <div
+              key={i}
+              className={`${barHeight} flex-1`}
+              style={{ backgroundColor: i < filled ? color : '#E8E8E8' }}
+            />
+          ))}
         </div>
       )}
     </div>

--- a/network-topology-mapper/frontend/src/components/shared/StatusBadge.tsx
+++ b/network-topology-mapper/frontend/src/components/shared/StatusBadge.tsx
@@ -1,12 +1,5 @@
 import { STATUS_COLORS } from '../../lib/graph-utils';
 import type { DeviceStatus } from '../../types/topology';
-import { CheckCircle, XCircle, AlertTriangle } from 'lucide-react';
-
-const statusIcons: Record<DeviceStatus, React.ElementType> = {
-  online: CheckCircle,
-  offline: XCircle,
-  degraded: AlertTriangle,
-};
 
 interface Props {
   status: DeviceStatus;
@@ -14,15 +7,14 @@ interface Props {
   size?: number;
 }
 
-export default function StatusBadge({ status, showLabel = true, size = 12 }: Props) {
-  const color = STATUS_COLORS[status] || '#6B7280';
-  const Icon = statusIcons[status] || CheckCircle;
+export default function StatusBadge({ status, showLabel = true, size = 8 }: Props) {
+  const color = STATUS_COLORS[status] || '#999999';
 
   return (
     <span className="inline-flex items-center gap-1.5">
-      <Icon size={size} color={color} />
+      <span className="rounded-full" style={{ width: size, height: size, backgroundColor: color }} />
       {showLabel && (
-        <span className="text-xs capitalize" style={{ color }}>
+        <span className="font-mono text-label uppercase tracking-[0.08em]" style={{ color }}>
           {status}
         </span>
       )}

--- a/network-topology-mapper/frontend/src/index.css
+++ b/network-topology-mapper/frontend/src/index.css
@@ -15,14 +15,14 @@ html, body, #root {
 }
 
 body {
-  font-family: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #111113;
-  color: #ECECED;
+  font-family: 'Space Grotesk', 'DM Sans', system-ui, sans-serif;
+  background-color: #F5F5F5;
+  color: #1A1A1A;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Scrollbar */
+/* Scrollbar — light mode */
 ::-webkit-scrollbar {
   width: 6px;
   height: 6px;
@@ -33,17 +33,50 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.12);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.14);
+  background: rgba(0, 0, 0, 0.2);
 }
 
-/* Monospace for data */
+/* Monospace data font */
 .font-mono {
-  font-family: 'JetBrains Mono', 'Consolas', monospace;
+  font-family: 'Space Mono', 'JetBrains Mono', 'SF Mono', monospace;
+}
+
+/* Display font (Doto) */
+.font-display {
+  font-family: 'Doto', 'Space Mono', monospace;
+}
+
+/* Nothing ALL CAPS label style */
+.nd-label {
+  font-family: 'Space Mono', monospace;
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #666666;
+}
+
+/* Dot-grid background */
+.dot-grid {
+  background-image: radial-gradient(circle, #CCCCCC 1px, transparent 1px);
+  background-size: 16px 16px;
+}
+
+.dot-grid-subtle {
+  background-image: radial-gradient(circle, #E8E8E8 0.5px, transparent 0.5px);
+  background-size: 12px 12px;
+}
+
+/* Nothing-style inline status text */
+.nd-status {
+  font-family: 'Space Mono', monospace;
+  font-size: 12px;
+  letter-spacing: 0.04em;
 }
 
 @layer utilities {

--- a/network-topology-mapper/frontend/src/lib/cytoscape-config.ts
+++ b/network-topology-mapper/frontend/src/lib/cytoscape-config.ts
@@ -1,4 +1,3 @@
-import { DEVICE_TYPE_COLORS, CONNECTION_TYPE_COLORS } from './graph-utils';
 import { getDeviceIcon } from './node-icons';
 
 // Node size tiers by device importance
@@ -14,195 +13,168 @@ const NODE_SIZES: Record<string, number> = {
   unknown: 36,
 };
 
+// Nothing light-mode: monochrome graph with status-colored borders only.
+// White nodes, dark icons, thin borders. Clean technical diagram.
 export const cytoscapeStylesheet: any[] = [
-  // ─── Base node: circular with clean label below ───
+  // ─── Base node: white circle, dark border, icon inside ───
   {
     selector: 'node',
     style: {
       shape: 'ellipse',
       width: 36,
       height: 36,
-      'background-color': '#6B7280',
-      'border-width': 2,
-      'border-color': '#475569',
+      'background-color': '#FFFFFF',
+      'border-width': 1.5,
+      'border-color': '#CCCCCC',
       label: 'data(label)',
       'text-valign': 'bottom',
       'text-halign': 'center',
       'text-margin-y': 8,
-      'font-size': 11,
-      'font-family': 'Inter, system-ui, sans-serif',
-      color: '#CBD5E1',
+      'font-size': 10,
+      'font-family': "'Space Mono', monospace",
+      'text-transform': 'uppercase',
+      color: '#666666',
       'text-max-width': '90px',
       'text-wrap': 'ellipsis',
       'text-overflow-wrap': 'anywhere',
       'background-image': getDeviceIcon('unknown' as any),
-      'background-width': 20,
-      'background-height': 20,
+      'background-width': 18,
+      'background-height': 18,
       'background-position-x': '50%',
       'background-position-y': '50%',
       'background-clip': 'none',
       'background-image-containment': 'over',
       'z-index': 10,
       'overlay-opacity': 0,
-      'transition-property': 'opacity, border-color, border-width, shadow-blur, shadow-opacity, width, height',
-      'transition-duration': '200ms',
+      'transition-property': 'opacity, border-color, border-width, width, height',
+      'transition-duration': '150ms',
     },
   },
 
-  // ─── Device type: color fills, icons, and tiered sizes ───
-  ...Object.entries(DEVICE_TYPE_COLORS).map(([type, color]) => ({
+  // ─── Device types: sized tiers with correct icons ───
+  ...Object.keys(NODE_SIZES).map((type) => ({
     selector: `node[device_type = "${type}"]`,
     style: {
-      'background-color': color,
-      'border-color': color,
       width: NODE_SIZES[type] || 36,
       height: NODE_SIZES[type] || 36,
       'background-image': getDeviceIcon(type as any),
-      'background-width': Math.round((NODE_SIZES[type] || 36) * 0.5),
-      'background-height': Math.round((NODE_SIZES[type] || 36) * 0.5),
-      'background-position-x': '50%',
-      'background-position-y': '50%',
+      'background-width': Math.round((NODE_SIZES[type] || 36) * 0.45),
+      'background-height': Math.round((NODE_SIZES[type] || 36) * 0.45),
     } as any,
   })),
 
-  // ─── Status indicators ───
+  // ─── Status: border color is the only color on the graph ───
   {
     selector: 'node[status = "online"]',
     style: {
-      'border-color': '#34D399',
-      'border-width': 2.5,
+      'border-color': '#4A9E5C',
+      'border-width': 2,
     },
   },
   {
     selector: 'node[status = "offline"]',
     style: {
-      'border-color': '#EF4444',
-      'border-width': 3,
+      'border-color': '#D71921',
+      'border-width': 2,
       'border-style': 'dashed',
-      opacity: 0.6,
+      opacity: 0.5,
     },
   },
   {
     selector: 'node[status = "degraded"]',
     style: {
-      'border-color': '#F59E0B',
-      'border-width': 3,
+      'border-color': '#D4A843',
+      'border-width': 2,
       'border-style': 'double',
     },
   },
 
-  // ─── Gateway nodes: slightly larger with diamond border accent ───
+  // ─── Gateway nodes: slightly larger ───
   {
     selector: 'node[?is_gateway]',
     style: {
       width: 56,
       height: 56,
-      'border-width': 3,
+      'border-width': 2.5,
       'font-weight': 'bold',
-      color: '#F0F4F8',
+      color: '#1A1A1A',
     },
   },
 
-  // ─── SPOF nodes: pulsing red warning ring ───
+  // ─── SPOF nodes: red border — the accent event ───
   {
     selector: 'node[?isSPOF]',
     style: {
-      'shadow-blur': 20,
-      'shadow-color': '#EF4444',
-      'shadow-opacity': 0.7,
-      'border-color': '#EF4444',
+      'border-color': '#D71921',
       'border-width': 3,
     },
   },
 
-  // ─── Risk scores ───
+  // ─── High risk ───
   {
     selector: 'node[risk_score > 8.0]',
     style: {
-      'shadow-blur': 25,
-      'shadow-color': '#EF4444',
-      'shadow-opacity': 0.6,
+      'border-color': '#D71921',
+      'border-width': 2.5,
     },
   },
   {
     selector: 'node[risk_score > 5.0][risk_score <= 8.0]',
     style: {
-      'shadow-blur': 15,
-      'shadow-color': '#F97316',
-      'shadow-opacity': 0.4,
+      'border-color': '#D4A843',
+      'border-width': 2,
     },
   },
 
-  // ─── Selected state: white ring + blue glow + scale up ───
+  // ─── Selected state: black ring, no shadow, scale up ───
   {
     selector: ':selected',
     style: {
       'border-width': 3,
-      'border-color': '#ffffff',
-      'shadow-blur': 30,
-      'shadow-color': '#3B82F6',
-      'shadow-opacity': 0.7,
+      'border-color': '#000000',
       'overlay-opacity': 0,
       width: (ele: any) => (NODE_SIZES[ele.data('device_type')] || 36) + 8,
       height: (ele: any) => (NODE_SIZES[ele.data('device_type')] || 36) + 8,
       'z-index': 100,
       'font-weight': 'bold',
-      color: '#F0F4F8',
+      color: '#1A1A1A',
     },
   },
 
-  // ─── Base edge style: smooth bezier ───
+  // ─── Base edge: thin gray line ───
   {
     selector: 'edge',
     style: {
-      width: 1.5,
-      'line-color': '#334155',
+      width: 1,
+      'line-color': '#CCCCCC',
       'curve-style': 'bezier',
       'target-arrow-shape': 'none',
-      opacity: 0.5,
+      opacity: 0.6,
       'transition-property': 'opacity, line-color, width',
-      'transition-duration': '200ms',
+      'transition-duration': '150ms',
     },
   },
 
-  // ─── Edge connection types ───
+  // ─── Edge types: differentiated by line style, not color ───
   {
     selector: 'edge[connection_type = "ethernet"]',
-    style: {
-      'line-color': CONNECTION_TYPE_COLORS.ethernet,
-      'line-style': 'solid',
-    },
+    style: { 'line-style': 'solid' },
   },
   {
     selector: 'edge[connection_type = "fiber"]',
-    style: {
-      'line-color': CONNECTION_TYPE_COLORS.fiber,
-      'line-style': 'solid',
-      width: 3,
-    },
+    style: { 'line-style': 'solid', width: 2 },
   },
   {
     selector: 'edge[connection_type = "wireless"]',
-    style: {
-      'line-color': CONNECTION_TYPE_COLORS.wireless,
-      'line-style': 'dashed',
-      'line-dash-pattern': [6, 3],
-    },
+    style: { 'line-style': 'dashed', 'line-dash-pattern': [6, 3] },
   },
   {
     selector: 'edge[connection_type = "vpn"]',
-    style: {
-      'line-color': CONNECTION_TYPE_COLORS.vpn,
-      'line-style': 'dotted',
-    },
+    style: { 'line-style': 'dotted' },
   },
   {
     selector: 'edge[connection_type = "virtual"]',
-    style: {
-      'line-color': CONNECTION_TYPE_COLORS.virtual,
-      'line-style': 'dashed',
-      width: 1,
-    },
+    style: { 'line-style': 'dashed', width: 0.75 },
   },
 
   // ─── Dependency edges ───
@@ -211,47 +183,39 @@ export const cytoscapeStylesheet: any[] = [
     style: {
       'line-style': 'dotted',
       'target-arrow-shape': 'triangle',
-      'target-arrow-color': '#A78BFA',
-      'line-color': '#A78BFA',
+      'target-arrow-color': '#999999',
+      'line-color': '#999999',
       opacity: 0.3,
-      width: 1.5,
+      width: 1,
       'curve-style': 'unbundled-bezier',
     },
   },
 
-  // ─── Flapping edge ───
+  // ─── Flapping edge — the one accent moment ───
   {
     selector: 'edge[status = "flapping"]',
-    style: {
-      'line-color': '#F87171',
-      width: 3,
-    },
+    style: { 'line-color': '#D71921', width: 2 },
   },
 
   // ─── Disabled edge ───
   {
     selector: 'edge[status = "disabled"]',
-    style: {
-      opacity: 0.1,
-      'line-style': 'dashed',
-    },
+    style: { opacity: 0.1, 'line-style': 'dashed' },
   },
 
   // ─── Redundant edge ───
   {
     selector: 'edge[?is_redundant]',
-    style: {
-      'line-color': '#34D399',
-    },
+    style: { 'line-color': '#4A9E5C', opacity: 0.4 },
   },
 
   // ─── Selected edge ───
   {
     selector: 'edge:selected',
     style: {
-      width: 4,
+      width: 2.5,
       opacity: 1,
-      'line-color': '#60A5FA',
+      'line-color': '#1A1A1A',
       'z-index': 50,
     },
   },
@@ -260,71 +224,75 @@ export const cytoscapeStylesheet: any[] = [
   {
     selector: '.sim-removed',
     style: {
-      'background-color': '#F87171',
+      'background-color': '#F0F0F0',
       opacity: 0.3,
       'border-style': 'dashed',
-      'border-color': '#F87171',
+      'border-color': '#D71921',
     },
   },
   {
     selector: '.sim-disconnected',
     style: {
-      'background-color': '#7F1D1D',
-      opacity: 0.6,
-      'border-color': '#EF4444',
-      'shadow-blur': 15,
-      'shadow-color': '#EF4444',
+      opacity: 0.5,
+      'border-color': '#D71921',
+      'border-width': 2.5,
     },
   },
   {
     selector: '.sim-degraded',
     style: {
-      'border-color': '#FBBF24',
-      'shadow-blur': 10,
-      'shadow-color': '#FBBF24',
+      'border-color': '#D4A843',
+      'border-width': 2.5,
     },
   },
   {
     selector: '.sim-safe',
     style: {
-      'background-color': '#065F46',
-      'border-color': '#34D399',
-      'shadow-blur': 10,
-      'shadow-color': '#34D399',
+      'border-color': '#4A9E5C',
+      'border-width': 2.5,
     },
   },
 
-  // ─── Neighborhood highlight classes (last to override everything) ───
+  // ─── Hover label: show hostname above node ───
+  {
+    selector: 'node.hovered',
+    style: {
+      label: (ele: any) => ele.data('hostname') || ele.data('ip') || '',
+      'text-valign': 'top',
+      'text-margin-y': -10,
+      'font-size': 14,
+      'font-family': "Space Grotesk, system-ui, sans-serif",
+      'font-weight': 'bold',
+      color: '#000000',
+      'text-max-width': '200px',
+      'text-wrap': 'none',
+      'z-index': 90,
+    },
+  },
+
+  // ─── Neighborhood highlight (last to override) ───
   {
     selector: 'node.highlighted',
     style: {
-      'border-color': '#ffffff',
-      'shadow-blur': 20,
-      'shadow-color': '#ffffff',
-      'shadow-opacity': 0.4,
+      'border-color': '#000000',
+      'border-width': 2.5,
       'z-index': 50,
     },
   },
   {
     selector: 'node.dimmed',
-    style: {
-      opacity: 0.15,
-      'z-index': 1,
-    },
+    style: { opacity: 0.12, 'z-index': 1 },
   },
   {
     selector: 'edge.dimmed',
-    style: {
-      opacity: 0.08,
-      'z-index': 1,
-    },
+    style: { opacity: 0.06, 'z-index': 1 },
   },
   {
     selector: 'edge.highlighted',
     style: {
       opacity: 1,
-      'line-color': '#60A5FA',
-      width: 3,
+      'line-color': '#1A1A1A',
+      width: 2,
       'z-index': 50,
     },
   },
@@ -332,8 +300,8 @@ export const cytoscapeStylesheet: any[] = [
     selector: 'edge.edge-hovered',
     style: {
       opacity: 1,
-      'line-color': '#93C5FD',
-      width: 3.5,
+      'line-color': '#000000',
+      width: 2.5,
       'z-index': 60,
     },
   },
@@ -348,7 +316,7 @@ export const dagreLayoutOptions = {
   rankSep: 140,
   ranker: 'network-simplex',
   animate: true,
-  animationDuration: 500,
+  animationDuration: 400,
   fit: true,
   padding: 50,
   spacingFactor: 1.2,
@@ -357,7 +325,7 @@ export const dagreLayoutOptions = {
 export const colaLayoutOptions = {
   name: 'cola',
   animate: true,
-  animationDuration: 500,
+  animationDuration: 400,
   nodeSpacing: 40,
   edgeLength: 200,
   maxSimulationTime: 4000,
@@ -369,7 +337,7 @@ export const colaLayoutOptions = {
 export const circleLayoutOptions = {
   name: 'circle',
   animate: true,
-  animationDuration: 500,
+  animationDuration: 400,
   fit: true,
   padding: 50,
   avoidOverlap: true,
@@ -378,7 +346,7 @@ export const circleLayoutOptions = {
 export const gridLayoutOptions = {
   name: 'grid',
   animate: true,
-  animationDuration: 500,
+  animationDuration: 400,
   fit: true,
   padding: 50,
   avoidOverlap: true,

--- a/network-topology-mapper/frontend/src/lib/graph-utils.ts
+++ b/network-topology-mapper/frontend/src/lib/graph-utils.ts
@@ -1,29 +1,31 @@
 import type { DeviceType, ConnectionType, DeviceStatus } from '../types/topology';
 
+// Nothing light-mode: monochrome nodes. Device types differentiated by shape/icon,
+// not fill color. These are used only for the minimap dots and legend.
 export const DEVICE_TYPE_COLORS: Record<DeviceType, string> = {
-  router: '#818CF8', // Indigo-400
-  switch: '#60A5FA', // Blue-400
-  server: '#34D399', // Emerald-400
-  firewall: '#FBBF24', // Amber-400
-  ap: '#A78BFA', // Violet-400
-  workstation: '#94A3B8', // Slate-400
-  iot: '#F472B6', // Pink-400
-  printer: '#FB923C', // Orange-400
-  unknown: '#6B7280', // Gray-500
+  router: '#1A1A1A',
+  switch: '#333333',
+  server: '#4D4D4D',
+  firewall: '#1A1A1A',
+  ap: '#666666',
+  workstation: '#808080',
+  iot: '#999999',
+  printer: '#808080',
+  unknown: '#CCCCCC',
 };
 
 export const STATUS_COLORS: Record<DeviceStatus, string> = {
-  online: '#34D399', // Emerald-400
-  offline: '#F87171', // Red-400
-  degraded: '#FBBF24', // Amber-400
+  online: '#4A9E5C',
+  offline: '#D71921',
+  degraded: '#D4A843',
 };
 
 export const CONNECTION_TYPE_COLORS: Record<ConnectionType, string> = {
-  ethernet: '#475569', // Slate-600
-  fiber: '#818CF8', // Indigo-400
-  wireless: '#A78BFA', // Violet-400
-  vpn: '#FBBF24', // Amber-400
-  virtual: '#94A3B8', // Slate-400
+  ethernet: '#CCCCCC',
+  fiber: '#999999',
+  wireless: '#CCCCCC',
+  vpn: '#CCCCCC',
+  virtual: '#CCCCCC',
 };
 
 export const CONNECTION_TYPE_STYLES: Record<ConnectionType, string> = {
@@ -35,10 +37,10 @@ export const CONNECTION_TYPE_STYLES: Record<ConnectionType, string> = {
 };
 
 export function getRiskColor(score: number): string {
-  if (score < 0.3) return '#34D399';
-  if (score < 0.6) return '#FBBF24';
-  if (score < 0.8) return '#FB923C';
-  return '#F87171';
+  if (score < 0.3) return '#4A9E5C';
+  if (score < 0.6) return '#D4A843';
+  if (score < 0.8) return '#D4A843';
+  return '#D71921';
 }
 
 export function getRiskLabel(score: number): string {
@@ -64,8 +66,6 @@ export function truncate(str: string, max: number = 16): string {
 
 export function formatTimeAgo(dateStr: string): string {
   if (!dateStr) return 'unknown';
-  // Backend stores UTC timestamps without a Z suffix — append it so
-  // the browser parses them as UTC instead of local time.
   const normalized = dateStr.endsWith('Z') || dateStr.includes('+') ? dateStr : dateStr + 'Z';
   const date = new Date(normalized);
   const now = new Date();
@@ -99,22 +99,22 @@ export function formatDate(dateStr: string): string {
 
 export function getSeverityColor(severity: string): string {
   switch (severity) {
-    case 'critical': return '#EF4444';
-    case 'high': return '#F97316';
-    case 'medium': return '#F59E0B';
-    case 'low': return '#3B82F6';
-    case 'info': return '#6B7280';
-    default: return '#6B7280';
+    case 'critical': return '#D71921';
+    case 'high': return '#D71921';
+    case 'medium': return '#D4A843';
+    case 'low': return '#666666';
+    case 'info': return '#999999';
+    default: return '#999999';
   }
 }
 
 export function getSeverityIcon(severity: string): string {
   switch (severity) {
-    case 'critical': return '🔴';
-    case 'high': return '🟠';
-    case 'medium': return '🟡';
-    case 'low': return '🔵';
-    case 'info': return '⚪';
-    default: return '⚪';
+    case 'critical': return '\u25CF';  // filled circle
+    case 'high': return '\u25CF';
+    case 'medium': return '\u25CB';    // open circle
+    case 'low': return '\u25CB';
+    case 'info': return '\u25CB';
+    default: return '\u25CB';
   }
 }

--- a/network-topology-mapper/frontend/src/lib/node-icons.ts
+++ b/network-topology-mapper/frontend/src/lib/node-icons.ts
@@ -1,42 +1,27 @@
 import { DeviceType } from '../types/topology';
 
-// Helper to encode SVG strings
 const encodeSvg = (svg: string) => `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 
-// Darker stroke colors that contrast against the device-type fill backgrounds
-const ICON_STROKE_COLORS: Record<DeviceType, string> = {
-    router: '#312e81',     // indigo-900 (against indigo-400 bg)
-    switch: '#1e3a5f',     // dark blue (against blue-400 bg)
-    server: '#064e3b',     // emerald-900 (against emerald-400 bg)
-    firewall: '#78350f',   // amber-900 (against amber-400 bg)
-    ap: '#4c1d95',         // violet-900 (against violet-400 bg)
-    workstation: '#1e293b', // slate-800 (against slate-400 bg)
-    iot: '#831843',        // pink-900 (against pink-400 bg)
-    printer: '#7c2d12',    // orange-900 (against orange-400 bg)
-    unknown: '#374151',    // gray-700 (against gray-500 bg)
+// Nothing design: monoline icons, 1.5px stroke, dark on light.
+// All icons use the same stroke color for monochrome consistency.
+const STROKE = '#1A1A1A';
+
+const ICONS: Record<DeviceType, string> = {
+    router: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${STROKE}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="8" x="2" y="14" rx="2"/><path d="M6.01 18h.01"/><path d="M10.01 18h.01"/><path d="M15 10v4"/><path d="M17.84 7.17a4 4 0 0 0-5.66 0"/><path d="M20.66 4.34a8 8 0 0 0-11.31 0"/></svg>`,
+    switch: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${STROKE}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m16 11 2 2 4-4"/><path d="M2 13v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6"/><path d="M2 19h20"/><path d="M10 11l-2 2-4-4"/></svg>`,
+    server: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${STROKE}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="8" x="2" y="2" rx="2" ry="2"/><rect width="20" height="8" x="2" y="14" rx="2" ry="2"/><line x1="6" x2="6.01" y1="6" y2="6"/><line x1="6" x2="6.01" y1="18" y2="18"/></svg>`,
+    firewall: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${STROKE}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>`,
+    ap: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${STROKE}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12.55a11 11 0 0 1 14.08 0"/><path d="M1.42 9a16 16 0 0 1 21.16 0"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" x2="12.01" y1="20" y2="20"/></svg>`,
+    workstation: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${STROKE}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="3" rx="2"/><line x1="8" x2="16" y1="21" y2="21"/><line x1="12" x2="12" y1="17" y2="21"/></svg>`,
+    printer: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${STROKE}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect width="12" height="8" x="6" y="14"/></svg>`,
+    iot: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${STROKE}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect width="16" height="16" x="4" y="4" rx="2"/><rect width="6" height="6" x="9" y="9" rx="1"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg>`,
+    unknown: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${STROKE}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>`,
 };
 
-// SVG Icons (simplified versions of Lucide icons) with device-type stroke colors
-function buildIcons(strokeColor: string) {
-    return {
-        router: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${strokeColor}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="8" x="2" y="14" rx="2"/><path d="M6.01 18h.01"/><path d="M10.01 18h.01"/><path d="M15 10v4"/><path d="M17.84 7.17a4 4 0 0 0-5.66 0"/><path d="M20.66 4.34a8 8 0 0 0-11.31 0"/></svg>`,
-        switch: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${strokeColor}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m16 11 2 2 4-4"/><path d="M2 13v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6"/><path d="M2 19h20"/><path d="M10 11l-2 2-4-4"/></svg>`,
-        server: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${strokeColor}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="8" x="2" y="2" rx="2" ry="2"/><rect width="20" height="8" x="2" y="14" rx="2" ry="2"/><line x1="6" x2="6.01" y1="6" y2="6"/><line x1="6" x2="6.01" y1="18" y2="18"/></svg>`,
-        firewall: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${strokeColor}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>`,
-        ap: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${strokeColor}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12.55a11 11 0 0 1 14.08 0"/><path d="M1.42 9a16 16 0 0 1 21.16 0"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" x2="12.01" y1="20" y2="20"/></svg>`,
-        workstation: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${strokeColor}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="3" rx="2"/><line x1="8" x2="16" y1="21" y2="21"/><line x1="12" x2="12" y1="17" y2="21"/></svg>`,
-        printer: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${strokeColor}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 6 2 18 2 18 9"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><rect width="12" height="8" x="6" y="14"/></svg>`,
-        iot: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${strokeColor}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect width="16" height="16" x="4" y="4" rx="2"/><rect width="6" height="6" x="9" y="9" rx="1"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg>`,
-        unknown: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${strokeColor}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>`,
-    };
-}
-
-// Pre-build icon cache per device type
 const ICON_CACHE: Record<DeviceType, string> = {} as any;
 
-for (const [type, strokeColor] of Object.entries(ICON_STROKE_COLORS)) {
-    const icons = buildIcons(strokeColor);
-    ICON_CACHE[type as DeviceType] = encodeSvg(icons[type as keyof typeof icons]);
+for (const [type, svg] of Object.entries(ICONS)) {
+    ICON_CACHE[type as DeviceType] = encodeSvg(svg);
 }
 
 export function getDeviceIcon(type: DeviceType): string {

--- a/network-topology-mapper/frontend/src/stores/filterStore.ts
+++ b/network-topology-mapper/frontend/src/stores/filterStore.ts
@@ -31,8 +31,8 @@ interface FilterState {
 }
 
 export const useFilterStore = create<FilterState>((set) => ({
-  activeLayer: 'physical',
-  activeLayout: 'dagre',
+  activeLayer: 'logical',
+  activeLayout: 'cola',
   deviceTypeFilter: [],
   statusFilter: [],
   vlanFilter: [],

--- a/network-topology-mapper/frontend/tailwind.config.ts
+++ b/network-topology-mapper/frontend/tailwind.config.ts
@@ -5,75 +5,64 @@ const config: Config = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Plus Jakarta Sans', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'sans-serif'],
-        mono: ['JetBrains Mono', 'Consolas', 'monospace'],
+        display: ['Doto', 'Space Mono', 'monospace'],
+        sans: ['Space Grotesk', 'DM Sans', 'system-ui', 'sans-serif'],
+        mono: ['Space Mono', 'JetBrains Mono', 'SF Mono', 'monospace'],
+      },
+      fontSize: {
+        'display-xl': ['72px', { lineHeight: '1.0', letterSpacing: '-0.03em' }],
+        'display-lg': ['48px', { lineHeight: '1.05', letterSpacing: '-0.02em' }],
+        'display-md': ['36px', { lineHeight: '1.1', letterSpacing: '-0.02em' }],
+        'heading': ['24px', { lineHeight: '1.2', letterSpacing: '-0.01em' }],
+        'subheading': ['18px', { lineHeight: '1.3', letterSpacing: '0' }],
+        'body': ['16px', { lineHeight: '1.5', letterSpacing: '0' }],
+        'body-sm': ['14px', { lineHeight: '1.5', letterSpacing: '0.01em' }],
+        'caption': ['12px', { lineHeight: '1.4', letterSpacing: '0.04em' }],
+        'label': ['11px', { lineHeight: '1.2', letterSpacing: '0.08em' }],
       },
       colors: {
-        bg: {
-          primary: '#111113',
-          secondary: '#19191B',
-          tertiary: '#222225',
-          surface: '#19191B',
+        nd: {
+          // Light mode surfaces
+          black: '#F5F5F5',
+          surface: '#FFFFFF',
+          'surface-raised': '#F0F0F0',
+          // Borders
+          border: '#E8E8E8',
+          'border-visible': '#CCCCCC',
+          // Text hierarchy
+          'text-disabled': '#999999',
+          'text-secondary': '#666666',
+          'text-primary': '#1A1A1A',
+          'text-display': '#000000',
+          // Accent & status
+          accent: '#D71921',
+          'accent-subtle': 'rgba(215,25,33,0.15)',
+          success: '#4A9E5C',
+          warning: '#D4A843',
+          interactive: '#007AFF',
         },
-        text: {
-          primary: '#ECECED',
-          secondary: '#8B8B8E',
-          muted: '#5C5C5F',
-        },
-        accent: {
-          DEFAULT: '#6366F1',
-          light: '#818CF8',
-          muted: '#4F46E5',
-        },
-        node: {
-          router: '#818CF8',
-          switch: '#60A5FA',
-          server: '#34D399',
-          firewall: '#FBBF24',
-          ap: '#A78BFA',
-          workstation: '#94A3B8',
-          iot: '#F472B6',
-          unknown: '#5C5C5F',
-          printer: '#FB923C',
-        },
-        status: {
-          online: '#34D399',
-          offline: '#F87171',
-          degraded: '#FBBF24',
-          new: '#60A5FA',
-        },
-        risk: {
-          low: '#34D399',
-          medium: '#FBBF24',
-          high: '#FB923C',
-          critical: '#F87171',
-        },
-        edge: {
-          ethernet: '#3F3F46',
-          fiber: '#818CF8',
-          wireless: '#A78BFA',
-          vpn: '#FBBF24',
-          virtual: '#8B8B8E',
-        },
-        border: {
-          DEFAULT: '#27272A',
-          light: '#2E2E32',
-        },
+      },
+      spacing: {
+        'nd-2xs': '2px',
+        'nd-xs': '4px',
+        'nd-sm': '8px',
+        'nd-md': '16px',
+        'nd-lg': '24px',
+        'nd-xl': '32px',
+        'nd-2xl': '48px',
+        'nd-3xl': '64px',
+        'nd-4xl': '96px',
+      },
+      borderRadius: {
+        'nd-technical': '4px',
+        'nd-compact': '8px',
+        'nd-card': '12px',
+        'nd-pill': '999px',
       },
       animation: {
-        'slide-in-right': 'slide-in-right 0.2s ease-out',
-        'slide-in-top': 'slide-in-top 0.25s ease-out',
-        'fade-in': 'fade-in 0.15s ease-out',
+        'fade-in': 'fade-in 0.15s cubic-bezier(0.25, 0.1, 0.25, 1)',
       },
       keyframes: {
-        'slide-in-right': {
-          '0%': { transform: 'translateX(100%)', opacity: '0' },
-          '100%': { transform: 'translateX(0)', opacity: '1' },
-        },
-        'slide-in-top': {
-          '0%': { transform: 'translateY(-8px)', opacity: '0' },
-          '100%': { transform: 'translateY(0)', opacity: '1' },
-        },
         'fade-in': {
           '0%': { opacity: '0' },
           '100%': { opacity: '1' },


### PR DESCRIPTION
Replace the existing dark-theme SaaS aesthetic with a light-mode design system. Monochromatic palette, typographically driven hierarchy.

Design tokens: Doto (display), Space Grotesk (body), Space Mono (labels). Light mode: off-white #F5F5F5 bg, white surfaces, black text, red accent. Segmented progress bars, ALL CAPS monospace labels, pill buttons, dot-grid canvas background, monoline 1.5px icons.

All 9 views restyled: Topology, Dashboard, Scan, Simulate, Alerts, Heatmap, Timeline, Reports, Settings. Node click opens inspector panel with connected-devices list. Hover shows hostname label. Removed floating tooltip and command palette.

Backend: added POST /api/topology/import endpoint for bulk data import.