### PR TITLE
docs: update all docs for bare-metal development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 Network Topology Scanner (NTS) is a network discovery and visualization tool that scans your LAN, infers device connections, and renders an interactive topology graph. It uses nmap, SNMP, and passive scanning to build a SQLite + NetworkX topology database, then serves it to a React frontend via FastAPI WebSocket. An IsolationForest model flags anomalous devices. Claude API generates natural language resilience reports.
 
-The project targets small-to-medium networks (home labs, small offices). Development runs bare metal (Python venv + npm). Redis is optional (app falls back to in-memory).
+The project targets small-to-medium networks (home labs, small offices). Development runs bare metal (Python venv + npm). Redis is optional but some features (pub/sub, caching) are unavailable without it.
 
 ## Directory Structure
 
@@ -166,7 +166,7 @@ Do not change without team discussion.
 | State management | Zustand |
 | Scanning | nmap (subprocess, NOT python-nmap), Scapy (passive), pysnmp, Netmiko |
 | Anomaly detection | scikit-learn IsolationForest |
-| AI reports | Claude Code (headless subprocess) |
+| AI reports | Anthropic Claude API (Python SDK) |
 | Infra | Bare metal (Python venv + npm). Redis optional. |
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 Network Topology Scanner (NTS) is a network discovery and visualization tool that scans your LAN, infers device connections, and renders an interactive topology graph. It uses nmap, SNMP, and passive scanning to build a SQLite + NetworkX topology database, then serves it to a React frontend via FastAPI WebSocket. An IsolationForest model flags anomalous devices. Claude API generates natural language resilience reports.
 
-The project targets small-to-medium networks (home labs, small offices). The team uses Docker Compose for all development and demo work.
+The project targets small-to-medium networks (home labs, small offices). Development runs bare metal (Python venv + npm). Redis is optional (app falls back to in-memory).
 
 ## Directory Structure
 
@@ -22,14 +22,11 @@ Network-Topology-Scanner/
 │   └── Problem-Statement.md
 └── network-topology-mapper/        ← All application code lives here
     ├── demo.sh                     ← Start/stop/scan/status commands
-    ├── docker-compose.yml          ← Core services (backend, frontend, redis, demo containers)
-    ├── docker-compose.demo.yml     ← Demo network overlay (5 simulated devices on nts-net)
     ├── .env.example                ← Template — copy to .env for local dev
-    ├── .env.demo                   ← Pre-configured for Docker demo
+    ├── .env.dockerless             ← Pre-configured for bare-metal dev
     ├── .gitignore
     ├── README.md
     ├── backend/                    ← FastAPI Python backend
-    │   ├── Dockerfile
     │   ├── requirements.txt
     │   ├── app/
     │   │   ├── main.py             ← App entry point, lifespan, router registration
@@ -80,8 +77,6 @@ Network-Topology-Scanner/
     │   └── tests/
     │       └── test_connection_inference.py
     ├── frontend/                   ← React 18 + TypeScript + Vite
-    │   ├── Dockerfile
-    │   ├── nginx.conf
     │   └── src/
     │       ├── App.tsx
     │       ├── components/
@@ -118,11 +113,11 @@ Network-Topology-Scanner/
 
 1. **Do NOT create new top-level directories** inside `network-topology-mapper/` without team discussion.
 2. **Do NOT move files** between `backend/app/` subdirectories without understanding the import chain.
-3. **Do NOT modify** `docker-compose.yml` service names or `nts-net` network configuration — other compose files depend on it.
+3. **Do NOT modify** environment variable names in `.env.example` — other config files depend on them.
 4. **Do NOT add Celery back.** Scheduling uses asyncio in `main.py` lifespan. This was a deliberate architectural decision.
 5. **Do NOT commit `.env` files.** Use `.env.example` as the template. `.env.demo` is committed intentionally (no secrets).
 6. **Do NOT modify `Research-Paper/`** without explicit team discussion — this is shared academic work.
-7. **All backend code** goes under `backend/app/`. No Python files at `backend/` root except `requirements.txt` and `Dockerfile`.
+7. **All backend code** goes under `backend/app/`. No Python files at `backend/` root except `requirements.txt`.
 8. **All frontend components** follow the existing subdirectory convention: `components/dashboard/`, `components/graph/`, `components/layout/`, `components/panels/`, `components/shared/`.
 9. **New API routes** get their own file in `routers/` and must be registered in `main.py`.
 10. **New services** get their own file in the appropriate `services/` subdirectory.
@@ -171,15 +166,15 @@ Do not change without team discussion.
 | State management | Zustand |
 | Scanning | nmap (subprocess, NOT python-nmap), Scapy (passive), pysnmp, Netmiko |
 | Anomaly detection | scikit-learn IsolationForest |
-| AI reports | Anthropic Claude API |
-| Infra | Docker Compose, bridge networking (`nts-net`), nginx reverse proxy |
+| AI reports | Claude Code (headless subprocess) |
+| Infra | Bare metal (Python venv + npm). Redis optional. |
 
 ---
 
 ## Key Architecture Decisions
 
-**Bridge networking (`nts-net`) — NOT `network_mode: host`.**
-Required for Mac compatibility. All inter-service communication uses Docker service names.
+**Bare metal, not Docker.**
+Backend runs via uvicorn, frontend via Vite dev server. No Docker required for development.
 
 **Connection inference runs unconditionally as Phase 5 of every scan.**
 `scan_coordinator.py` runs 5 phases: active nmap → passive Scapy → SNMP → config pull → inference. Phase 5 (`connection_inference.py`) uses gateway + switch-aware strategies to infer edges even when LLDP is unavailable (home networks).
@@ -200,26 +195,19 @@ All device and connection data is persisted in SQLite with NetworkX used for in-
 ## Development Workflow
 
 ```bash
-# Run the full demo (requires Docker only):
-cd network-topology-mapper
-./demo.sh up        # Starts all services + demo network (~60s for healthy state)
-./demo.sh scan      # Triggers a scan against 172.20.0.0/24
-./demo.sh status    # Health check
-./demo.sh down      # Tear down
+# Backend:
+cd network-topology-mapper/backend
+python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 8000
+
+# Frontend (separate terminal):
+cd network-topology-mapper/frontend
+npm install && npm run dev
+
 # Frontend:   http://localhost:3000
 # Backend API: http://localhost:8000/api
 # API docs:   http://localhost:8000/docs
-
-# Backend bare-metal dev (editing Python code):
-cd network-topology-mapper/backend
-python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
-# Optionally start Redis via Docker for pubsub, then:
-uvicorn app.main:app --reload --port 8000
-
-# Frontend dev:
-cd network-topology-mapper/frontend
-npm install && npm run dev
 ```
 
 ---
@@ -228,8 +216,7 @@ npm install && npm run dev
 
 - **Backend:** `cd backend && python -m pytest tests/` — must pass
 - **Frontend:** `cd frontend && npm run build` — must succeed (no TypeScript errors)
-- **Docker config changed:** `./demo.sh down && ./demo.sh up` — all services must reach healthy state
-- **Scan logic changed:** `./demo.sh scan` — verify devices + edges appear in the frontend graph
+- **Scan logic changed:** trigger a scan from the UI and verify devices + edges appear in the frontend graph
 
 ---
 

--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -1,26 +1,30 @@
 # Quick Start Guide
 
-## Demo Mode (Recommended — Zero Config)
+## Setup
 
-The fastest path to a working topology graph. Uses Docker with 5 simulated network containers.
+### Prerequisites
+- Python 3.11+
+- Node.js 18+
+- nmap
+
+### Install & Run
 
 ```bash
 cd network-topology-mapper
 
-# Start full stack + demo network (~60s for all containers to reach healthy state)
-./demo.sh up
+# Backend
+cd backend
+python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 8000
 
-# Trigger a scan once services are healthy
-./demo.sh scan
-
-# Open http://localhost:3000 to see the topology graph
+# Frontend (separate terminal)
+cd frontend
+npm install
+npm run dev
 ```
 
-**What you get:** nginx web server, Postgres DB, file server (SSH+SMB), JetDirect printer, SNMP device — all on `nts-net` (172.20.0.0/24). The backend scans them with nmap, runs connection inference, and renders a topology graph.
-
-```bash
-./demo.sh down    # tear down when done
-```
+Open http://localhost:3000 to see the topology graph.
 
 ---
 
@@ -34,14 +38,16 @@ cd network-topology-mapper
 
 ---
 
-## Scan Your Own Network
+## Scan Your Network
 
-With the stack running, trigger a scan against your real LAN:
+Click **Scan** in the sidebar, enter your subnet (e.g. `192.168.1.0/24`), select intensity, and hit scan.
+
+Or via CLI:
 
 ```bash
-curl -X POST http://localhost:8000/api/scan \
+curl -X POST http://localhost:8000/api/scans \
   -H "Content-Type: application/json" \
-  -d '{"target": "192.168.1.0/24"}'
+  -d '{"type": "full", "target": "192.168.1.0/24", "intensity": "normal"}'
 
 # Check progress
 curl http://localhost:8000/api/scans | jq
@@ -67,34 +73,28 @@ curl http://localhost:8000/api/alerts | jq
 
 ---
 
-## Local Development (Without Docker)
-
-For bare-metal backend development, see `INSTALL_GUIDE.md`.
-
----
-
 ## Troubleshooting
 
 **Graph shows no devices after scan:**
 - Wait for scan to complete: `curl http://localhost:8000/api/scans | jq`
-- Check scan target matches the demo network: `172.20.0.0/24`
-- Try `./demo.sh scan` instead of a manual curl
+- Verify nmap is installed: `nmap --version`
+- On Linux, nmap may need elevated privileges: `sudo setcap cap_net_raw,cap_net_admin=eip $(which nmap)`
 
-**Services won't start:**
-- Ensure Docker has at least 4 GB RAM allocated
-- Check for port conflicts: `lsof -i :3000; lsof -i :8000; lsof -i :7474`
-- Try `./demo.sh down && ./demo.sh up`
+**Backend won't start:**
+- Check Python version: `python --version` (needs 3.11+)
+- Make sure venv is activated
+- Check port 8000 isn't in use
 
 **Frontend shows empty graph after scan completes:**
-- Hard refresh: `Cmd+Shift+R` (macOS) or `Ctrl+Shift+R` (Linux)
-- Check backend logs: `docker logs network-topology-mapper-backend-1`
+- Hard refresh: `Cmd+Shift+R` (macOS) or `Ctrl+Shift+R` (Windows/Linux)
+- Check backend terminal for errors
 
 ---
 
 ## More Documentation
 
 - `CLAUDE.md` — agent constitution, directory structure, sacred rules
-- `INSTALL_GUIDE.md` — manual database installation
+- `INSTALL_GUIDE.md` — detailed setup
 - `docs/ARCHITECTURE.md` — system architecture
 - `docs/API.md` — full API reference
 - `docs/TROUBLESHOOTING.md` — common issues

--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -18,7 +18,7 @@ python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\acti
 pip install -r requirements.txt
 uvicorn app.main:app --reload --port 8000
 
-# Frontend (separate terminal)
+# Frontend (separate terminal, from network-topology-mapper/)
 cd frontend
 npm install
 npm run dev

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ cd network-topology-mapper
 cd backend
 python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
-uvicorn app.main:app --reload --port 8000 &
+uvicorn app.main:app --reload --port 8000
 
-# Frontend
-cd ../frontend
+# Frontend (separate terminal)
+cd network-topology-mapper/frontend
 npm install
 npm run dev
 ```
@@ -60,6 +60,7 @@ curl -X POST http://localhost:8000/api/scans \
 ## Docs
 
 - `CLAUDE.md` — agent constitution, directory structure, sacred rules
+- `QUICK_START_GUIDE.md` — standalone quickstart path
 - `INSTALL_GUIDE.md` — bare-metal setup details
 - `docs/ARCHITECTURE.md` — system architecture, scan pipeline, data flow
 - `docs/API.md` — full API reference

--- a/README.md
+++ b/README.md
@@ -6,33 +6,32 @@ Network discovery and visualization tool. Scans your LAN with nmap + SNMP + pass
 
 ---
 
-## Quickstart (Demo Mode)
+## Quickstart
 
-Requires Docker only.
+### Prerequisites
+
+- Python 3.11+
+- Node.js 18+
+- nmap
+
+### Run
 
 ```bash
 cd network-topology-mapper
-./demo.sh up      # starts all services + 5 demo network containers (~60s)
-./demo.sh scan    # triggers scan against demo network
-./demo.sh status  # health check
+
+# Backend
+cd backend
+python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 8000 &
+
+# Frontend
+cd ../frontend
+npm install
+npm run dev
 ```
 
-Open http://localhost:3000 to see the topology graph.
-
-The demo network has: nginx web server, Postgres DB, file server (SSH+SMB), JetDirect printer, SNMP device — all on `nts-net` (172.20.0.0/24).
-
-```bash
-./demo.sh down    # tear down when done
-```
-
----
-
-## Prerequisites
-
-- Docker 20.10+ and Docker Compose 2.0+
-- 4 GB RAM available for Docker
-
-For local (non-Docker) development, see `INSTALL_GUIDE.md`.
+Open http://localhost:3000, click **Scan** in the sidebar, and scan your network.
 
 ---
 
@@ -48,14 +47,12 @@ For local (non-Docker) development, see `INSTALL_GUIDE.md`.
 
 ## Scan Your Own Network
 
-```bash
-# Trigger a scan against your LAN
-curl -X POST http://localhost:8000/api/scan \
-  -H "Content-Type: application/json" \
-  -d '{"target": "192.168.1.0/24"}'
+Use the Scan page in the UI, or via CLI:
 
-# Check topology stats
-curl http://localhost:8000/api/topology/stats | jq
+```bash
+curl -X POST http://localhost:8000/api/scans \
+  -H "Content-Type: application/json" \
+  -d '{"type": "full", "target": "192.168.1.0/24", "intensity": "normal"}'
 ```
 
 ---
@@ -63,11 +60,9 @@ curl http://localhost:8000/api/topology/stats | jq
 ## Docs
 
 - `CLAUDE.md` — agent constitution, directory structure, sacred rules
-- `QUICK_START_GUIDE.md` — demo quickstart
-- `INSTALL_GUIDE.md` — database setup for local dev
+- `INSTALL_GUIDE.md` — bare-metal setup details
 - `docs/ARCHITECTURE.md` — system architecture, scan pipeline, data flow
 - `docs/API.md` — full API reference
-- `docs/SETUP.md` — detailed setup guide
 - `docs/CONTRIBUTING.md` — branch conventions, PR process
 - `docs/TROUBLESHOOTING.md` — common issues and fixes
 
@@ -75,4 +70,4 @@ curl http://localhost:8000/api/topology/stats | jq
 
 ## Tech Stack
 
-Python 3.11 / FastAPI / SQLite + NetworkX / Redis 7 — React 18 / TypeScript / Vite / Cytoscape.js / Zustand / Tailwind CSS
+Python 3.11 / FastAPI / SQLite + NetworkX / Redis (optional) — React 18 / TypeScript / Vite / Cytoscape.js / Zustand / Tailwind CSS

--- a/network-topology-mapper/README.md
+++ b/network-topology-mapper/README.md
@@ -2,8 +2,6 @@
 
 A real-time network topology mapping and analysis platform that discovers devices, visualizes network relationships, identifies single points of failure, and provides AI-powered resilience insights.
 
-![Network Topology Mapper](docs/images/screenshot-main.png)
-
 ## Features
 
 - **Automated Network Discovery**: Active scanning (nmap), passive monitoring (Scapy), SNMP polling, and device configuration retrieval
@@ -12,7 +10,7 @@ A real-time network topology mapping and analysis platform that discovers device
 - **SPOF Detection**: Automatically identify single points of failure using graph analysis
 - **Real-time Monitoring**: WebSocket-based live updates for topology changes, alerts, and scan progress
 - **Risk Scoring**: Composite risk assessment for devices and overall network health
-- **AI-Powered Reports**: Natural language resilience reports powered by Claude API
+- **AI-Powered Reports**: Natural language resilience reports powered by Claude
 - **Anomaly Detection**: Machine learning-based detection of unusual topology changes
 - **Multi-Layer Views**: Physical, logical, and application layer visualization
 
@@ -21,7 +19,6 @@ A real-time network topology mapping and analysis platform that discovers device
 ### Frontend
 - **React 18** + TypeScript + Vite
 - **Cytoscape.js** for network graph visualization
-- **Recharts** for metrics and analytics
 - **Tailwind CSS** for styling
 - **Zustand** for state management
 - **WebSocket** for real-time updates
@@ -29,87 +26,52 @@ A real-time network topology mapping and analysis platform that discovers device
 ### Backend
 - **FastAPI** (Python 3.11+)
 - **SQLite** + **NetworkX** for device/connection storage and graph analysis
-- **Redis** for caching and real-time pub/sub
-- **SQLite** for scan history, alerts, topology snapshots, and settings
+- **Redis** for caching and real-time pub/sub (optional — falls back to in-memory)
 - **asyncio-based task scheduler** for periodic scans and post-scan analysis
-- **NetworkX** for graph analysis
 - **scikit-learn** for anomaly detection (IsolationForest)
 
 ### Networking Tools
-- python-nmap for active scanning
+- nmap (subprocess) for active scanning
 - Scapy for passive packet capture
 - pysnmp for SNMP interrogation
 - Netmiko for device configuration retrieval
 
 ## Quick Start
 
-### Demo Mode (Zero Configuration)
-
-The fastest way to see NTS working end-to-end. Spins up the full stack plus 5 scannable demo containers on a private Docker network.
-
-**Prerequisites:** Docker, docker-compose
-
-```bash
-git clone <repository-url>
-cd network-topology-mapper
-
-# Start the full stack + demo network
-./demo.sh up
-
-# Once all services are healthy (~60s), trigger a scan
-./demo.sh scan
-
-# Check backend health
-./demo.sh status
-```
-
-**What happens:**
-- 5 demo containers start on `nts-net` (172.20.0.0/24): `web-server` (nginx), `db-server` (postgres), `file-server` (SSH+SMB), `printer` (JetDirect+IPP), `snmp-device` (net-snmp)
-- nmap discovers all containers on the bridge network
-- Connection inference creates star-topology edges through the Docker gateway (172.20.0.1)
-- Frontend at http://localhost:3000 renders the live topology graph
-- Topology stored in SQLite, graph analysis via NetworkX
-
-**Tear down:**
-```bash
-./demo.sh down
-```
-
-### Production Setup
-
 ### Prerequisites
 
-- Docker & Docker Compose
-- Python 3.11+ (for local development)
-- Node.js 18+ (for frontend development)
-- Redis (optional — app falls back to in-memory)
+- Python 3.11+
+- Node.js 18+
+- nmap (`brew install nmap` / `apt install nmap` / [nmap.org](https://nmap.org/download))
 
-### Using Docker Compose
+### Setup
 
-1. Clone the repository:
 ```bash
-git clone <repository-url>
-cd network-topology-mapper
+# Backend
+cd backend
+python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 8000
+
+# Frontend (separate terminal)
+cd frontend
+npm install
+npm run dev
 ```
 
-2. Create environment configuration:
-```bash
-cp .env.example .env
-# Edit .env with your settings
-```
-
-3. Start all services:
-```bash
-docker-compose up -d
-```
-
-4. Access the application:
 - Frontend: http://localhost:3000
 - Backend API: http://localhost:8000
+- API docs: http://localhost:8000/docs
 
-### Local Development
+### Scan Your Network
 
-See [SETUP.md](docs/SETUP.md) for detailed local development setup instructions.
+Open http://localhost:3000, click **Scan** in the sidebar, enter your subnet (e.g. `192.168.1.0/24`), and hit scan. Or via CLI:
+
+```bash
+curl -X POST http://localhost:8000/api/scans \
+  -H "Content-Type: application/json" \
+  -d '{"type": "full", "target": "192.168.1.0/24", "intensity": "normal"}'
+```
 
 ## Project Structure
 
@@ -119,17 +81,17 @@ network-topology-mapper/
 │   ├── app/
 │   │   ├── main.py            # Application entry point
 │   │   ├── config.py          # Configuration management
-│   │   ├── models/            # Pydantic and SQLAlchemy models
+│   │   ├── models/            # Pydantic models
 │   │   ├── routers/           # API route handlers
 │   │   ├── services/          # Business logic
 │   │   │   ├── scanner/       # Network scanning services
 │   │   │   ├── graph/         # Graph analysis and manipulation
 │   │   │   ├── ai/            # AI/ML services
 │   │   │   └── realtime/      # WebSocket and event handling
-│   │   ├── tasks/             # Celery background tasks
-│   │   └── db/                # Database clients and connections
+│   │   ├── tasks/             # asyncio background tasks
+│   │   └── db/                # Database clients (topology_db, sqlite_db, redis_client)
 │   ├── requirements.txt
-│   └── Dockerfile
+│   └── tests/
 ├── frontend/                   # React frontend
 │   ├── src/
 │   │   ├── components/        # React components
@@ -142,20 +104,9 @@ network-topology-mapper/
 │   │   ├── stores/            # Zustand state stores
 │   │   ├── lib/               # Utilities and configurations
 │   │   └── types/             # TypeScript type definitions
-│   ├── package.json
-│   └── vite.config.ts
+│   └── package.json
 ├── docs/                       # Documentation
-│   ├── ARCHITECTURE.md        # System architecture details
-│   ├── API.md                 # API endpoint documentation
-│   ├── SETUP.md               # Setup and installation guide
-│   ├── CONTRIBUTING.md        # Contribution guidelines
-│   └── DEPLOYMENT.md          # Deployment instructions
-├── testing/                    # Test documentation
-│   ├── SMOKE_TEST.md
-│   └── TEST_CHECKLIST.md
-├── docker-compose.yml
-├── .env.example
-└── README.md
+└── testing/                    # Test checklists
 ```
 
 ## Documentation
@@ -164,36 +115,6 @@ network-topology-mapper/
 - [API Documentation](docs/API.md) - Complete API reference
 - [Setup Guide](docs/SETUP.md) - Installation and configuration
 - [Contributing Guide](docs/CONTRIBUTING.md) - How to contribute
-- [Frontend Components](docs/FRONTEND.md) - Component documentation
-- [Backend Services](docs/BACKEND.md) - Backend service documentation
-- [Deployment Guide](docs/DEPLOYMENT.md) - Production deployment
-
-## Key Concepts
-
-### Device Types
-- **Routers**: Core routing devices
-- **Switches**: Layer 2/3 switches
-- **Servers**: Application and service hosts
-- **Firewalls**: Security perimeter devices
-- **Access Points**: Wireless infrastructure
-- **Workstations**: End-user devices
-- **IoT**: Smart devices and sensors
-- **Unknown**: Unidentified devices
-
-### Connection Types
-- **Ethernet**: Standard wired connections
-- **Fiber**: High-speed fiber links
-- **Wireless**: Wi-Fi connections
-- **VPN**: Virtual private network tunnels
-- **Virtual**: Virtualized network connections
-
-### Risk Scoring
-Risk scores (0.0-1.0) are calculated based on:
-- Connectivity redundancy
-- Device criticality
-- Number of dependencies
-- Configuration vulnerabilities
-- Historical reliability
 
 ## Usage Examples
 
@@ -216,54 +137,13 @@ curl -X POST http://localhost:8000/api/simulate/failure \
   -d '{"remove_nodes": ["device-uuid-here"]}'
 ```
 
-### View Topology Snapshots
-```bash
-curl http://localhost:8000/api/snapshots
-```
-
-### Get Scan Optimizer Recommendations
-```bash
-curl http://localhost:8000/api/scan-optimizer/recommendations
-```
-
 ### Read / Update Settings
 ```bash
-# Get current settings
 curl http://localhost:8000/api/settings
 
-# Update scan interval and target range
 curl -X PUT http://localhost:8000/api/settings \
   -H "Content-Type: application/json" \
-  -d '{"scan_interval_minutes": 10, "scan_default_range": "172.20.0.0/24"}'
-```
-
-## Development
-
-### Backend Development
-```bash
-cd backend
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
-pip install -r requirements.txt
-uvicorn app.main:app --reload
-```
-
-### Frontend Development
-```bash
-cd frontend
-npm install
-npm run dev
-```
-
-### Running Tests
-```bash
-# Backend tests
-cd backend
-pytest
-
-# Frontend tests
-cd frontend
-npm test
+  -d '{"scan_interval_minutes": 10, "scan_default_range": "192.168.1.0/24"}'
 ```
 
 ## Configuration
@@ -271,15 +151,12 @@ npm test
 Key environment variables (see `.env.example` for full list):
 
 ```bash
-# Redis (optional)
+# Redis (optional — app works without it)
 REDIS_URL=redis://localhost:6379/0
 
 # Scanning
-SCAN_DEFAULT_RANGE=192.168.0.0/16
+SCAN_DEFAULT_RANGE=192.168.1.0/24
 SNMP_COMMUNITY=public
-
-# Claude API (for AI reports)
-ANTHROPIC_API_KEY=sk-ant-...
 
 # Agent Mode
 AGENT_MODE=alert  # alert | interactive | autonomous
@@ -287,74 +164,24 @@ AGENT_MODE=alert  # alert | interactive | autonomous
 
 ## Security Considerations
 
-- Network scanning requires elevated privileges (NET_RAW, NET_ADMIN capabilities)
-- Secure your Redis instance with a strong password
+- Network scanning requires elevated privileges (nmap needs NET_RAW/NET_ADMIN or root)
 - Keep SNMP community strings confidential
 - Restrict API access in production environments
 - Review firewall rules before active scanning
 
-## Performance Tips
-
-- Use targeted scans instead of full network sweeps for faster discovery
-- Enable passive scanning for continuous monitoring without active probing
-- Adjust scan rate limits based on network capacity
-- Use Redis caching to reduce database load
-- Limit WebSocket client connections in production
-
-## Troubleshooting
-
-### Scanning Permission Errors
-Ensure Docker container has proper capabilities:
-```yaml
-cap_add:
-  - NET_RAW
-  - NET_ADMIN
-```
-
-### WebSocket Disconnections
-Check WebSocket heartbeat interval and firewall settings. Increase timeout in config if needed.
-
 ## Contributing
 
 We welcome contributions! Please see [CONTRIBUTING.md](docs/CONTRIBUTING.md) for guidelines.
-
-## License
-
-[Specify your license here]
 
 ## Acknowledgments
 
 - Built with [Cytoscape.js](https://js.cytoscape.org/) for graph visualization
 - Powered by [FastAPI](https://fastapi.tiangolo.com/) for the backend
 - Network analysis using [NetworkX](https://networkx.org/)
-- AI insights from [Claude API](https://www.anthropic.com/api)
-
-## Support
-
-For issues, questions, or suggestions:
-- Open an issue on GitHub
-- Check the [documentation](docs/)
-- Review [troubleshooting guide](docs/TROUBLESHOOTING.md)
-
-## Roadmap
-
-- [ ] Advanced traffic analysis integration
-- [ ] Multi-site topology management
-- [ ] Enhanced GNN-based failure prediction
-- [ ] Mobile responsive interface
-- [ ] SNMP trap receiver
-- [ ] Integration with CMDB systems
-- [ ] Custom alert rules engine
-- [ ] Automated remediation workflows
-
----
-
-**Status**: Active Development | **Version**: 1.0.0 | **Last Updated**: March 2026
 
 ## Known Limitations
 
-- **Anomaly detection requires 5+ topology snapshots** to train the IsolationForest model. During initial demo runs, only rule-based detection (flapping links, unknown devices) is active. After 5 scheduled scans have run, the ML model trains automatically.
-- **Passive scanning** (Scapy ARP sniffing) is disabled in demo mode — Docker bridge networking doesn't support raw packet capture across containers. Only nmap active scanning runs.
-- **SNMP polling** requires the `snmp-device` demo container to respond to the `public` community string on UDP 161. If the container starts slowly, the first scan may miss it.
-- **Settings changes** (via `PUT /api/settings`) take effect immediately for stored values, but `scan_interval_minutes` only applies to new scheduler instances. Restart the backend container to change the scan interval.
+- **Anomaly detection requires 5+ topology snapshots** to train the IsolationForest model. During initial use, only rule-based detection (flapping links, unknown devices) is active.
+- **Passive scanning** (Scapy ARP sniffing) requires root/admin privileges and may not work on all platforms.
+- **SNMP polling** requires devices that respond to the configured community string on UDP 161.
 - **Large topologies** (500+ devices) may slow down NetworkX graph analysis operations. Consider increasing scan intervals for very large networks.

--- a/network-topology-mapper/README.md
+++ b/network-topology-mapper/README.md
@@ -26,7 +26,7 @@ A real-time network topology mapping and analysis platform that discovers device
 ### Backend
 - **FastAPI** (Python 3.11+)
 - **SQLite** + **NetworkX** for device/connection storage and graph analysis
-- **Redis** for caching and real-time pub/sub (optional — falls back to in-memory)
+- **Redis** for caching and real-time pub/sub (optional — Redis-backed features like pub/sub and cache are unavailable without it)
 - **asyncio-based task scheduler** for periodic scans and post-scan analysis
 - **scikit-learn** for anomaly detection (IsolationForest)
 
@@ -53,8 +53,8 @@ python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\acti
 pip install -r requirements.txt
 uvicorn app.main:app --reload --port 8000
 
-# Frontend (separate terminal)
-cd frontend
+# Frontend (separate terminal, from project root)
+cd ../frontend
 npm install
 npm run dev
 ```
@@ -151,8 +151,11 @@ curl -X PUT http://localhost:8000/api/settings \
 Key environment variables (see `.env.example` for full list):
 
 ```bash
-# Redis (optional — app works without it)
+# Redis (optional — pub/sub and cache unavailable without it)
 REDIS_URL=redis://localhost:6379/0
+
+# AI Reports (optional — resilience reports require this)
+ANTHROPIC_API_KEY=your-api-key-here
 
 # Scanning
 SCAN_DEFAULT_RANGE=192.168.1.0/24


### PR DESCRIPTION
## Summary
- Rewrites README, QUICK_START_GUIDE, CLAUDE.md, and network-topology-mapper/README to reflect bare-metal as the primary development workflow
- Removes Docker as the default setup path
- Updates tech stack, architecture decisions, sacred rules, and dev workflow sections

## Test plan
- [ ] Docs read correctly with bare-metal instructions
- [ ] No misleading Docker-as-default language in top-level docs