### PR TITLE
Docs: make development docs local-first and mark Docker as optional demo-only (closes #16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 Network Topology Scanner (NTS) is a network discovery and visualization tool that scans your LAN, infers device connections, and renders an interactive topology graph. It uses nmap, SNMP, and passive scanning to build a SQLite + NetworkX topology database, then serves it to a React frontend via FastAPI WebSocket. An IsolationForest model flags anomalous devices. Claude API generates natural language resilience reports.
 
-The project targets small-to-medium networks (home labs, small offices). The team uses Docker Compose for all development and demo work.
+The project targets small-to-medium networks (home labs, small offices). The team uses local bare-metal development by default; Docker Compose is optional for demo network simulation.
 
 ## Directory Structure
 
@@ -118,7 +118,7 @@ Network-Topology-Scanner/
 
 1. **Do NOT create new top-level directories** inside `network-topology-mapper/` without team discussion.
 2. **Do NOT move files** between `backend/app/` subdirectories without understanding the import chain.
-3. **Do NOT modify** `docker-compose.yml` service names or `nts-net` network configuration — other compose files depend on it.
+3. **Do NOT modify** optional demo `docker-compose.yml` service names or `nts-net` network configuration — other compose files depend on it.
 4. **Do NOT add Celery back.** Scheduling uses asyncio in `main.py` lifespan. This was a deliberate architectural decision.
 5. **Do NOT commit `.env` files.** Use `.env.example` as the template. `.env.demo` is committed intentionally (no secrets).
 6. **Do NOT modify `Research-Paper/`** without explicit team discussion — this is shared academic work.
@@ -145,12 +145,12 @@ Examples:
 feat(scanner): add LLDP neighbor discovery
 fix(frontend): handle empty topology gracefully
 docs: update API reference
-chore(docker): bump redis to 7.4
+chore(deps): bump redis client version
 ```
 
 Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
 
-Scopes: `scanner`, `inference`, `graph`, `frontend`, `api`, `docker`, `demo`, `ai`
+Scopes: `scanner`, `inference`, `graph`, `frontend`, `api`, `demo`, `ai`, `deps`
 
 **Merge to `main` via PR. Never push directly to `main`.**
 
@@ -172,14 +172,14 @@ Do not change without team discussion.
 | Scanning | nmap (subprocess, NOT python-nmap), Scapy (passive), pysnmp, Netmiko |
 | Anomaly detection | scikit-learn IsolationForest |
 | AI reports | Anthropic Claude API |
-| Infra | Docker Compose, bridge networking (`nts-net`), nginx reverse proxy |
+| Infra | Local services by default; optional Docker Compose demo networking (`nts-net`); nginx reverse proxy |
 
 ---
 
 ## Key Architecture Decisions
 
-**Bridge networking (`nts-net`) — NOT `network_mode: host`.**
-Required for Mac compatibility. All inter-service communication uses Docker service names.
+**Optional demo bridge networking (`nts-net`) — NOT `network_mode: host`.**
+Required for Mac compatibility in demo mode.
 
 **Connection inference runs unconditionally as Phase 5 of every scan.**
 `scan_coordinator.py` runs 5 phases: active nmap → passive Scapy → SNMP → config pull → inference. Phase 5 (`connection_inference.py`) uses gateway + switch-aware strategies to infer edges even when LLDP is unavailable (home networks).
@@ -200,7 +200,17 @@ All device and connection data is persisted in SQLite with NetworkX used for in-
 ## Development Workflow
 
 ```bash
-# Run the full demo (requires Docker only):
+# Backend bare-metal dev (default for editing Python code):
+cd network-topology-mapper/backend
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 8000
+
+# Frontend dev:
+cd network-topology-mapper/frontend
+npm install && npm run dev
+
+# Optional demo network mode (requires Docker):
 cd network-topology-mapper
 ./demo.sh up        # Starts all services + demo network (~60s for healthy state)
 ./demo.sh scan      # Triggers a scan against 172.20.0.0/24
@@ -209,17 +219,6 @@ cd network-topology-mapper
 # Frontend:   http://localhost:3000
 # Backend API: http://localhost:8000/api
 # API docs:   http://localhost:8000/docs
-
-# Backend bare-metal dev (editing Python code):
-cd network-topology-mapper/backend
-python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
-# Optionally start Redis via Docker for pubsub, then:
-uvicorn app.main:app --reload --port 8000
-
-# Frontend dev:
-cd network-topology-mapper/frontend
-npm install && npm run dev
 ```
 
 ---
@@ -228,8 +227,8 @@ npm install && npm run dev
 
 - **Backend:** `cd backend && python -m pytest tests/` — must pass
 - **Frontend:** `cd frontend && npm run build` — must succeed (no TypeScript errors)
-- **Docker config changed:** `./demo.sh down && ./demo.sh up` — all services must reach healthy state
-- **Scan logic changed:** `./demo.sh scan` — verify devices + edges appear in the frontend graph
+- **Optional demo Docker config changed:** `./demo.sh down && ./demo.sh up` — all services must reach healthy state
+- **Scan logic changed:** run a scan from local backend and verify devices + edges appear in the frontend graph
 
 ---
 

--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-> **Recommended:** Use Demo Mode for development — no manual installation required. Run `./demo.sh up` from `network-topology-mapper/`. This guide covers manual setup for local bare-metal development.
+> **Recommended:** Use local bare-metal setup for development. Demo mode is optional and mainly useful when you want simulated network devices via `./demo.sh up` from `network-topology-mapper/`.
 
 ---
 

--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -1,8 +1,28 @@
 # Quick Start Guide
 
-## Demo Mode (Recommended — Zero Config)
+## Local Development (Recommended)
 
-The fastest path to a working topology graph. Uses Docker with 5 simulated network containers.
+The default path to a working topology graph runs directly on your machine.
+
+```bash
+cd network-topology-mapper/backend
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 8000
+
+cd ../frontend
+npm install
+npm run dev
+```
+
+Open http://localhost:3000 to see the topology graph.
+
+---
+
+## Optional Demo Mode (Docker)
+
+Use this mode when you want 5 simulated network devices.
 
 ```bash
 cd network-topology-mapper
@@ -67,9 +87,7 @@ curl http://localhost:8000/api/alerts | jq
 
 ---
 
-## Local Development (Without Docker)
-
-For bare-metal backend development, see `INSTALL_GUIDE.md`.
+For detailed local setup steps, see `INSTALL_GUIDE.md`.
 
 ---
 
@@ -81,13 +99,13 @@ For bare-metal backend development, see `INSTALL_GUIDE.md`.
 - Try `./demo.sh scan` instead of a manual curl
 
 **Services won't start:**
-- Ensure Docker has at least 4 GB RAM allocated
+- Ensure backend and frontend terminals are both running
 - Check for port conflicts: `lsof -i :3000; lsof -i :8000; lsof -i :7474`
-- Try `./demo.sh down && ./demo.sh up`
+- For demo mode only: try `./demo.sh down && ./demo.sh up`
 
 **Frontend shows empty graph after scan completes:**
 - Hard refresh: `Cmd+Shift+R` (macOS) or `Ctrl+Shift+R` (Linux)
-- Check backend logs: `docker logs network-topology-mapper-backend-1`
+- Check backend logs in the terminal running `uvicorn`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,27 @@ Network discovery and visualization tool. Scans your LAN with nmap + SNMP + pass
 
 ---
 
-## Quickstart (Demo Mode)
+## Quickstart (Local Development)
 
-Requires Docker only.
+Local development is the default workflow. Docker is optional and used for the demo lab only.
+
+```bash
+cd network-topology-mapper/backend
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 8000
+
+cd ../frontend
+npm install
+npm run dev
+```
+
+Open http://localhost:3000 to see the topology graph.
+
+## Optional Demo Mode (Docker)
+
+Use this mode when you want the simulated network devices in `demo/`.
 
 ```bash
 cd network-topology-mapper
@@ -16,8 +34,6 @@ cd network-topology-mapper
 ./demo.sh scan    # triggers scan against demo network
 ./demo.sh status  # health check
 ```
-
-Open http://localhost:3000 to see the topology graph.
 
 The demo network has: nginx web server, Postgres DB, file server (SSH+SMB), JetDirect printer, SNMP device — all on `nts-net` (172.20.0.0/24).
 
@@ -29,6 +45,12 @@ The demo network has: nginx web server, Postgres DB, file server (SSH+SMB), JetD
 
 ## Prerequisites
 
+- Python 3.11+
+- Node.js 18+
+- nmap
+- Redis 7 (optional, recommended for pub/sub)
+
+Optional for demo mode:
 - Docker 20.10+ and Docker Compose 2.0+
 - 4 GB RAM available for Docker
 
@@ -63,7 +85,7 @@ curl http://localhost:8000/api/topology/stats | jq
 ## Docs
 
 - `CLAUDE.md` — agent constitution, directory structure, sacred rules
-- `QUICK_START_GUIDE.md` — demo quickstart
+- `QUICK_START_GUIDE.md` — local quickstart + optional demo mode
 - `INSTALL_GUIDE.md` — database setup for local dev
 - `docs/ARCHITECTURE.md` — system architecture, scan pipeline, data flow
 - `docs/API.md` — full API reference

--- a/network-topology-mapper/backend/README.md
+++ b/network-topology-mapper/backend/README.md
@@ -77,9 +77,16 @@ cp .env.example .env
 # Edit .env with your settings
 ```
 
-4. **Start Redis** (optional — app works without it):
+4. **Start Redis** (optional - app works without it):
 ```bash
-docker run -d --name redis -p 6379:6379 redis:7-alpine
+# Linux (systemd)
+sudo systemctl start redis-server
+
+# macOS (Homebrew)
+brew services start redis
+
+# Optional alternative if you prefer containers
+# docker run -d --name redis -p 6379:6379 redis:7-alpine
 ```
 
 5. **Run server**:
@@ -430,12 +437,7 @@ topology = generate_mock_topology(device_count=100)
 
 ## Deployment
 
-### Docker
-
-```bash
-docker build -t network-mapper-backend .
-docker run -p 8000:8000 --env-file .env network-mapper-backend
-```
+Run behind a process manager/reverse proxy in production (for example `systemd` + `nginx`). Docker is optional and mainly used by the demo lab environment.
 
 ### Production Checklist
 

--- a/network-topology-mapper/docs/ARCHITECTURE.md
+++ b/network-topology-mapper/docs/ARCHITECTURE.md
@@ -78,9 +78,9 @@ Edges are stored in SQLite and analyzed with NetworkX in-memory graphs. The fron
 
 ---
 
-## Demo Network Architecture
+## Optional Demo Network Architecture (Docker)
 
-The Docker demo uses `docker-compose.demo.yml` as an overlay on top of `docker-compose.yml`. Five containers simulate a real network on the `nts-net` bridge (172.20.0.0/24):
+Docker is only used for the optional demo lab. The demo uses `docker-compose.demo.yml` as an overlay on top of `docker-compose.yml`. Five containers simulate a real network on the `nts-net` bridge (172.20.0.0/24):
 
 ```
 nts-net (172.20.0.0/24)
@@ -93,7 +93,7 @@ nts-net (172.20.0.0/24)
    └── snmp-device (alpine) ← port 161/UDP (SNMP)
 ```
 
-The backend uses nmap to scan 172.20.0.0/24, discovers these containers, runs connection inference, and stores the topology in SQLite.
+The backend uses nmap to scan 172.20.0.0/24, discovers these containers, runs connection inference, and stores the topology in SQLite. This demo setup is separate from the default local development workflow.
 
 ---
 
@@ -213,10 +213,11 @@ SQLite is the primary data store for all topology data:
 ## Security
 
 - No authentication implemented (planned for future)
-- Docker network isolation via `nts-net` bridge
+- Local development runs directly on host networking
+- Optional demo containers are isolated via the `nts-net` bridge
 - Redis requires authentication (configured in `.env`)
 - SNMP community string configurable
-- Scan capabilities granted via `cap_add: NET_RAW, NET_ADMIN` (not `network_mode: host`)
+- Scan capabilities must be granted on the host for local scanning (`setcap`/privileged execution)
 
 ---
 
@@ -230,4 +231,4 @@ SQLite is the primary data store for all topology data:
 
 **asyncio over Celery** — simpler ops, no broker to manage, sufficient for the scan frequency (minutes to hours, not seconds).
 
-**Bridge networking** — required for Mac compatibility; `network_mode: host` doesn't work on Mac Docker.
+**Optional demo bridge networking** — used by the demo lab for Mac compatibility; `network_mode: host` doesn't work on Mac Docker.

--- a/network-topology-mapper/docs/CONTRIBUTING.md
+++ b/network-topology-mapper/docs/CONTRIBUTING.md
@@ -25,13 +25,13 @@ Format: `type(scope): description`
 feat(scanner): add LLDP neighbor discovery
 fix(frontend): handle empty topology gracefully
 docs: update API reference
-chore(docker): bump redis to 7.4
+chore(deps): bump redis client version
 refactor(inference): simplify gateway detection logic
 test(scanner): add unit tests for SNMP poller
 ```
 
 Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
-Scopes: `scanner`, `inference`, `graph`, `frontend`, `api`, `docker`, `demo`, `ai`
+Scopes: `scanner`, `inference`, `graph`, `frontend`, `api`, `demo`, `ai`, `deps`
 
 ---
 
@@ -59,11 +59,12 @@ cd backend && python -m pytest tests/
 # Frontend build must succeed (no TypeScript errors)
 cd frontend && npm run build
 
-# If you changed Docker config:
+# If you changed optional demo Docker config:
 ./demo.sh down && ./demo.sh up   # all services must reach healthy state
 
 # If you changed scan logic:
-./demo.sh scan   # verify devices and edges appear in the graph
+# run a local scan against your dev target and verify devices/edges appear in graph
+curl -X POST http://localhost:8000/api/scans -H "Content-Type: application/json" -d '{"type":"full","target":"192.168.1.0/24"}'
 ```
 
 ---
@@ -86,6 +87,6 @@ These are enforced across all contributions — see `CLAUDE.md` for the full lis
 
 - No new top-level directories in `network-topology-mapper/` without team discussion
 - No Celery (scheduling uses asyncio in `main.py` lifespan)
-- No `network_mode: host` in Docker compose files (breaks Mac)
+- No `network_mode: host` in optional demo Docker compose files (breaks Mac)
 - Never commit `.env` files
 - Never touch `Research-Paper/` without team discussion

--- a/network-topology-mapper/docs/SETUP.md
+++ b/network-topology-mapper/docs/SETUP.md
@@ -5,7 +5,8 @@ Complete installation and configuration guide for Network Topology Mapper.
 ## Table of Contents
 
 - [System Requirements](#system-requirements)
-- [Quick Start with Docker](#quick-start-with-docker)
+- [Quick Start (Local Development)](#quick-start-local-development)
+- [Optional Demo Network (Docker)](#optional-demo-network-docker)
 - [Local Development Setup](#local-development-setup)
 - [Configuration](#configuration)
 - [Database Setup](#database-setup)
@@ -31,21 +32,21 @@ Complete installation and configuration guide for Network Topology Mapper.
 
 ### Software Prerequisites
 
-**For Docker Deployment** (recommended):
-- Docker 20.10+
-- Docker Compose 2.0+
-
-**For Local Development**:
+**Required for Local Development**:
 - Python 3.11+
 - Node.js 18+
 - Redis 7.0+
 - nmap (for network scanning)
 
+**Optional (Demo Network Lab Only)**:
+- Docker 20.10+
+- Docker Compose 2.0+
+
 ---
 
-## Quick Start with Docker
+## Quick Start (Local Development)
 
-The fastest way to get started is using the demo script.
+Use this path for day-to-day development. Docker is not required.
 
 ### 1. Clone Repository
 
@@ -70,47 +71,107 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 SCAN_DEFAULT_RANGE=192.168.0.0/16
 ```
 
-### 3. Start Services
+### 3. Backend Setup
+
+```bash
+cd backend
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+### 4. Start Redis (Local Service)
+
+Use your OS package/service manager to run Redis locally.
+
+**Ubuntu/Debian**:
+```bash
+sudo apt update
+sudo apt install -y redis-server
+sudo systemctl enable redis-server
+sudo systemctl start redis-server
+```
+
+**macOS**:
+```bash
+brew install redis
+brew services start redis
+```
+
+Verify:
+```bash
+redis-cli ping
+```
+
+Expected output: `PONG`
+
+### 5. Start Backend
+
+```bash
+cd backend
+source .venv/bin/activate
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+### 6. Frontend Setup
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+### 7. Trigger First Scan
+
+```bash
+curl -X POST http://localhost:8000/api/scan \
+  -H "Content-Type: application/json" \
+  -d '{"target": "192.168.1.0/24"}'
+```
+
+### 8. Access Application
+
+- **Main Application**: http://localhost:3000
+- **API Documentation**: http://localhost:8000/docs
+
+---
+
+## Optional Demo Network (Docker)
+
+Use this only when you want the simulated lab network in `demo/`.
+
+### 1. Start Demo Environment
 
 ```bash
 ./demo.sh up
 ```
 
-This starts all services on the `nts-net` bridge network:
-- Frontend (React) on http://localhost:3000
-- Backend (FastAPI) on http://localhost:8000
-- Redis on localhost:6379
+This starts demo containers on the `nts-net` bridge network.
 
-### 4. Trigger First Scan
+### 2. Trigger Demo Scan
 
 ```bash
 ./demo.sh scan
 ```
 
-Or via API:
-
-```bash
-curl -X POST http://localhost:8000/api/scan \
-  -H "Content-Type: application/json" \
-  -d '{"target": "172.20.0.0/24"}'
-```
-
-### 5. Access Application
-
-- **Main Application**: http://localhost:3000
-- **API Documentation**: http://localhost:8000/docs
-
-### 6. Status Check
+### 3. Check Demo Status
 
 ```bash
 ./demo.sh status
+```
+
+### 4. Tear Down Demo
+
+```bash
+./demo.sh down
 ```
 
 ---
 
 ## Local Development Setup
 
-For development without Docker (editing Python or frontend code directly).
+For direct backend/frontend development.
 
 ### Backend Setup
 
@@ -142,11 +203,14 @@ pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-#### 4. Start Redis via Docker
+#### 4. Start Redis (Local Service)
 
 ```bash
-# Start Redis (not the full app stack)
-docker run -d --name redis -p 6379:6379 redis:7-alpine
+# Ubuntu/Debian
+sudo systemctl start redis-server
+
+# macOS (Homebrew)
+brew services start redis
 ```
 
 #### 5. Configure Environment
@@ -291,20 +355,6 @@ python -c "from app.db.sqlite_db import init_db; init_db()"
 
 Network scanning requires elevated privileges for nmap and Scapy.
 
-### Docker Setup
-
-The backend container runs with bridge networking (`nts-net`). Scanning capabilities are granted via `cap_add` in `docker-compose.yml`:
-
-```yaml
-services:
-  backend:
-    cap_add:
-      - NET_RAW
-      - NET_ADMIN
-```
-
-This is already configured — no changes needed for the demo.
-
 ### Local Development Permissions
 
 **macOS**: nmap installed via Homebrew runs with the required capabilities by default.
@@ -343,8 +393,11 @@ sudo setcap cap_net_raw,cap_net_admin=eip $(which python3.11)
 **Error: "Redis connection refused"**
 
 ```bash
-docker start redis
-# or: docker run -d --name redis -p 6379:6379 redis:7-alpine
+# Ubuntu/Debian
+sudo systemctl start redis-server
+
+# macOS
+brew services start redis
 ```
 
 ### Frontend Won't Start
@@ -373,7 +426,7 @@ npx kill-port 3000
 
 - Reduce scan intensity
 - Reduce target subnet size
-- Check backend logs: `docker logs network-mapper-backend`
+- Check backend logs in your active `uvicorn` terminal output
 
 ### Database Issues
 
@@ -389,7 +442,7 @@ npx kill-port 3000
 
 - Reduce visible nodes with filters
 - Try dagre layout (faster than force-directed for large graphs)
-- Increase hardware resources allocated to Docker
+- Profile frontend render performance in browser DevTools
 
 ---
 

--- a/network-topology-mapper/docs/TROUBLESHOOTING.md
+++ b/network-topology-mapper/docs/TROUBLESHOOTING.md
@@ -11,7 +11,7 @@ Common issues and solutions for Network Topology Mapper.
 - [Performance Issues](#performance-issues)
 - [Frontend Problems](#frontend-problems)
 - [API Errors](#api-errors)
-- [Docker Issues](#docker-issues)
+- [Optional Demo Docker Issues](#optional-demo-docker-issues)
 
 ---
 
@@ -87,14 +87,11 @@ redis-cli ping
 
 1. **Start Redis**:
 ```bash
-# Docker
-docker-compose up -d redis
-
 # System service
 sudo systemctl start redis
 
-# Check logs
-docker logs redis
+# macOS (Homebrew)
+brew services start redis
 ```
 
 2. **Check configuration**:
@@ -180,16 +177,7 @@ sudo setcap cap_net_raw,cap_net_admin=eip /usr/bin/nmap
 # Log out and back in for group change
 ```
 
-4. **Docker**: Ensure proper capabilities (already configured in `docker-compose.yml`):
-```yaml
-# docker-compose.yml
-services:
-  backend:
-    cap_add:
-      - NET_RAW
-      - NET_ADMIN
-    # Uses bridge networking (nts-net) — do NOT set network_mode: host
-```
+4. **Optional demo containers**: If using the demo stack, capabilities are preconfigured in `docker-compose.yml`; this is not required for local development.
 
 ### No Devices Found During Scan
 
@@ -529,7 +517,8 @@ CACHE_TTL_TOPOLOGY=60  # Expire after 60 seconds
 3. **Restart services**:
 ```bash
 # Temporary fix
-docker-compose restart backend
+pkill -f "uvicorn app.main"
+uvicorn app.main:app --reload
 
 # Add healthcheck and auto-restart
 ```
@@ -664,7 +653,7 @@ curl -X POST http://localhost:8000/api/scans \
 **Diagnosis**:
 ```bash
 # Check backend logs
-docker-compose logs backend
+# Look at the terminal where uvicorn is running
 
 # Look for stack traces and exceptions
 ```
@@ -692,8 +681,6 @@ curl http://localhost:8000/health
 
 1. **Check backend is running**:
 ```bash
-docker-compose ps backend
-# or
 ps aux | grep uvicorn
 ```
 
@@ -708,12 +695,15 @@ df -h
 
 3. **Restart backend**:
 ```bash
-docker-compose restart backend
+pkill -f "uvicorn app.main"
+uvicorn app.main:app --reload
 ```
 
 ---
 
-## Docker Issues
+## Optional Demo Docker Issues
+
+This section only applies when running the optional demo lab in `demo/` via Docker Compose.
 
 ### Container Won't Start
 
@@ -753,7 +743,7 @@ cp .env.example .env
 sudo chown -R $USER:$USER ./data
 ```
 
-### Docker Compose Network Issues
+### Docker Compose Network Issues (Demo Only)
 
 **Problem**: Services cannot communicate
 
@@ -825,14 +815,12 @@ VITE_DEBUG=true
 uname -a
 python --version
 node --version
-docker --version
 
 # Service status
-docker-compose ps
 systemctl status redis
 
 # Logs
-docker-compose logs > logs.txt
+journalctl -u redis-server --no-pager | tail -100 > redis-logs.txt
 ```
 
 4. **Open GitHub Issue** with:


### PR DESCRIPTION
Clean up Docker references in documentation (closes #16)

### Summary

This PR cleans up stale Docker-first language across project documentation and aligns all setup guidance with the current bare-metal (local) development workflow.

### What changed

* Updated setup and quickstart docs to lead with local development
* Removed wording that implied Docker is required for development
* Retained Docker guidance only where it is needed for optional demo network containers
* Reworked contributing and troubleshooting instructions to reflect local-first workflows
* Clarified separation between default local workflow and optional demo Docker usage
* Synced messaging across top-level and nested documentation

### Files updated

* `README.md`
* `QUICK_START_GUIDE.md`
* `INSTALL_GUIDE.md`
* `CLAUDE.md`
* `network-topology-mapper/docs/ARCHITECTURE.md`
* `network-topology-mapper/docs/SETUP.md`
* `network-topology-mapper/docs/CONTRIBUTING.md`
* `network-topology-mapper/docs/TROUBLESHOOTING.md`
* `network-topology-mapper/backend/README.md`

### Why

Documentation was inconsistent after the shift to bare-metal development. Some sections still suggested Docker as the default or required setup, which could confuse new contributors and users.


### Validation

* Searched updated docs for any remaining "Docker required" or similar misleading phrasing
* Verified that remaining Docker references are clearly scoped to optional demo usage


### Result

* Documentation consistently reflects local (bare-metal) development as the default workflow
* Optional Docker usage for demo environments is clearly indicated
* Improved onboarding experience for new contributors
