### PR TITLE
Fix scan: stream verbose nmap progress to WebSocket during active scan closes #10

### DIFF
--- a/network-topology-mapper/backend/app/config.py
+++ b/network-topology-mapper/backend/app/config.py
@@ -15,6 +15,9 @@ class Settings(BaseSettings):
     scan_passive_interface: str = "eth0"
     snmp_community: str = "public"
     snmp_version: str = "2c"
+    enable_active_scan: bool = True
+    enable_passive_scan: bool = True
+    enable_snmp_scan: bool = True
 
     # SSH / Device Config
     ssh_username: str = "admin"

--- a/network-topology-mapper/backend/app/services/scanner/active_scanner.py
+++ b/network-topology-mapper/backend/app/services/scanner/active_scanner.py
@@ -1,6 +1,9 @@
 import logging
+import re
 import shutil
 import subprocess
+import threading
+import time
 import uuid
 import xml.etree.ElementTree as ET
 from datetime import datetime
@@ -39,17 +42,148 @@ class ActiveScanner:
             "deep": "--unprivileged -sT -sV -sC -PS21,22,80,139,443,445,3389,8080 --top-ports 1000 --host-timeout 30s -T4",
         }.get(intensity, "--unprivileged -sT -sV -PS21,22,80,443,445,3389 --top-ports 100 --host-timeout 10s -T4 --max-retries 1")
 
-        cmd = [self._nmap_path, "-oX", "-"] + args.split() + [target]
+        cmd = [
+            "stdbuf", "-oL", "-eL",
+            self._nmap_path,
+            "--stats-every", "5s",
+            "-v",
+            "-oX", "-",
+        ] + args.split() + [target]
         logger.info("Running nmap command: %s", " ".join(cmd))
 
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
 
-            if result.returncode != 0:
-                logger.error("Nmap failed with code %d: %s", result.returncode, result.stderr)
+            xml_lines: list[str] = []
+            stop_heartbeat = threading.Event()
+            started_at = time.time()
+            last_stats_at = [started_at]
+
+            def _safe_callback(payload: dict):
+                if not callback:
+                    return
+                try:
+                    callback(payload)
+                except Exception as cb_exc:
+                    logger.debug("Progress callback failed: %s", cb_exc)
+
+            def _parse_stats_line(line: str):
+                # nmap periodically emits lines like:
+                # Stats: 0:00:30 elapsed; 45 hosts completed (12 up), 209 remaining
+                # or: About 34.50% done; ETC: ...
+                percent = None
+                hosts_completed = None
+                hosts_up = None
+                hosts_total = None
+                elapsed = None
+
+                m_pct = re.search(r"About\s+([0-9]+(?:\.[0-9]+)?)%\s+done", line)
+                if m_pct:
+                    percent = float(m_pct.group(1))
+
+                m_elapsed = re.search(r"Stats:\s*([0-9:]+)\s+elapsed;", line)
+                if m_elapsed:
+                    elapsed = m_elapsed.group(1)
+
+                m_hosts = re.search(
+                    r"([0-9]+)\s+hosts\s+completed(?:\s*\(([0-9]+)\s+up\))?(?:,\s*([0-9]+)\s+remaining)?",
+                    line,
+                )
+                if m_hosts:
+                    hosts_completed = int(m_hosts.group(1))
+                    if m_hosts.group(2):
+                        hosts_up = int(m_hosts.group(2))
+                    if m_hosts.group(3):
+                        remaining = int(m_hosts.group(3))
+                        hosts_total = hosts_completed + remaining
+                        if percent is None and hosts_total > 0:
+                            percent = (hosts_completed / hosts_total) * 100.0
+
+                if percent is None and hosts_completed is None:
+                    return
+
+                msg_parts = []
+                if elapsed:
+                    msg_parts.append(f"elapsed {elapsed}")
+                if hosts_completed is not None and hosts_total:
+                    msg_parts.append(f"hosts {hosts_completed}/{hosts_total}")
+                elif hosts_completed is not None:
+                    msg_parts.append(f"hosts scanned {hosts_completed}")
+                if hosts_up is not None:
+                    msg_parts.append(f"up {hosts_up}")
+                if percent is not None:
+                    msg_parts.append(f"nmap {percent:.1f}%")
+
+                _safe_callback({
+                    "event": "nmap_progress",
+                    "percent": float(percent) if percent is not None else None,
+                    "hosts_completed": hosts_completed,
+                    "hosts_total": hosts_total,
+                    "hosts_up": hosts_up,
+                    "elapsed": elapsed,
+                    "message": "Nmap progress: " + ", ".join(msg_parts),
+                })
+                last_stats_at[0] = time.time()
+
+            def _heartbeat():
+                while not stop_heartbeat.is_set():
+                    now = time.time()
+                    # If nmap isn't emitting stats, provide a periodic progress heartbeat.
+                    if now - last_stats_at[0] >= 5:
+                        elapsed_s = int(now - started_at)
+                        _safe_callback({
+                            "event": "nmap_progress",
+                            "percent": None,
+                            "hosts_completed": None,
+                            "hosts_total": None,
+                            "hosts_up": None,
+                            "elapsed": f"{elapsed_s}s",
+                            "message": f"Nmap progress: elapsed {elapsed_s}s, running host/service probes...",
+                        })
+                        last_stats_at[0] = now
+                    stop_heartbeat.wait(1.0)
+
+            def _read_stdout():
+                if process.stdout is None:
+                    return
+                for line in process.stdout:
+                    xml_lines.append(line)
+
+            def _read_stderr():
+                if process.stderr is None:
+                    return
+                for line in process.stderr:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    logger.info("[nmap] %s", line)
+                    _parse_stats_line(line)
+
+            t_out = threading.Thread(target=_read_stdout, daemon=True)
+            t_err = threading.Thread(target=_read_stderr, daemon=True)
+            t_hb = threading.Thread(target=_heartbeat, daemon=True)
+            t_out.start()
+            t_err.start()
+            t_hb.start()
+
+            process.wait()
+            stop_heartbeat.set()
+            t_out.join(timeout=2)
+            t_err.join(timeout=2)
+            t_hb.join(timeout=2)
+
+            if process.returncode != 0:
+                logger.error("Nmap failed with code %d", process.returncode)
                 return []
 
-            root = ET.fromstring(result.stdout)
+            xml_output = "".join(xml_lines)
+            root = ET.fromstring(xml_output)
 
         except subprocess.TimeoutExpired:
             logger.error("Nmap scan timed out")

--- a/network-topology-mapper/backend/app/services/scanner/scan_coordinator.py
+++ b/network-topology-mapper/backend/app/services/scanner/scan_coordinator.py
@@ -220,9 +220,43 @@ class ScanCoordinator:
         return scan_id
 
     def _run_active_scan(self, scan_id: str, target: str, intensity: str):
+        last_progress_log = None
+
         def on_device_found(device):
+            nonlocal last_progress_log
+
+            if device.get("event") == "nmap_progress":
+                # Map nmap-internal percentage into active phase window (5% -> 34%).
+                nmap_percent = device.get("percent")
+                if isinstance(nmap_percent, (int, float)):
+                    phase_percent = 5 + int((float(nmap_percent) / 100.0) * 29)
+                else:
+                    phase_percent = 20
+
+                phase_percent = max(6, min(34, phase_percent))
+                msg = device.get("message") or "Nmap progress update"
+
+                # Avoid adding duplicate log lines on unchanged stats.
+                if msg != last_progress_log:
+                    self._publish_progress(
+                        scan_id,
+                        phase_percent,
+                        "active_scan",
+                        len(self._devices_cache),
+                        msg,
+                    )
+                    last_progress_log = msg
+                else:
+                    self._publish_progress(
+                        scan_id,
+                        phase_percent,
+                        "active_scan",
+                        len(self._devices_cache),
+                    )
+                return
+
             self._deduplicate_and_store(device)
-            self._publish_progress(scan_id, 20, "active_scan", len(self._devices_cache),
+            self._publish_progress(scan_id, 25, "active_scan", len(self._devices_cache),
                                    f"Discovered: {device.get('hostname') or device.get('ip', '?')}")
 
         devices = active_scanner.scan_network(target, intensity, callback=on_device_found)


### PR DESCRIPTION
### Overview
Fixes Phase 1 scan progress appearing stalled (~5%) by streaming live `nmap` updates via the existing `scan_progress` WebSocket channel.

### Problem
- Backend blocked until `nmap` completed  
- No intermediate progress updates  
- UI stuck at ~5% until completion  

### Changes

**Backend (`active_scanner.py`)**
- Switched to streaming subprocess execution  
- Enabled `nmap` stats (`--stats-every`, `-v`)  
- Parsed progress from `stderr`:
  - % complete (if available)  
  - Hosts done / remaining  
  - Elapsed time  
- Emitted structured progress events  
- Added ~5s heartbeat fallback  
- Concurrent `stdout`/`stderr` readers to avoid blocking  

**Coordinator (`scan_coordinator.py`)**
- Consumed `nmap_progress` events  
- Published updates via `scan_progress`  
- Mapped progress to Phase 1 (5% → ~34%)  
- Deduplicated noisy logs  

### Impact
- Continuous progress + logs during scans  
- No more “stuck at 5%” behavior  
- Real-time visibility into scan activity  

### Validation
- Verified via Docker demo flow  
- Smooth progress observed during Phase 1  
- No static analysis issues  

### Files
- `active_scanner.py`  
- `scan_coordinator.py`  

### Result
Improves UX by providing real-time scan progress without changing architecture or frontend.
Closes #10 