### PR TITLE
fix(scanner): replace nmap-only discovery with ping sweep + ARP

### DIFF
--- a/network-topology-mapper/backend/app/config.py
+++ b/network-topology-mapper/backend/app/config.py
@@ -1,5 +1,22 @@
 from pydantic_settings import BaseSettings
+from pydantic import model_validator
 from functools import lru_cache
+import ipaddress
+import socket
+
+
+def _detect_local_subnet() -> str:
+    """Detect the local network subnet (e.g. 192.168.1.0/24)."""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(0.5)
+        s.connect(("8.8.8.8", 80))
+        local_ip = s.getsockname()[0]
+        s.close()
+        network = ipaddress.ip_network(f"{local_ip}/24", strict=False)
+        return str(network)
+    except Exception:
+        return "192.168.0.0/24"
 
 
 class Settings(BaseSettings):
@@ -9,12 +26,21 @@ class Settings(BaseSettings):
     # SQLite
     sqlite_path: str = "./data/mapper.db"
 
-    # Scanning
-    scan_default_range: str = "192.168.0.0/16"
+    # Scanning (empty/blank = auto-detect local subnet)
+    scan_default_range: str = ""
     scan_rate_limit: int = 1000
     scan_passive_interface: str = "eth0"
     snmp_community: str = "public"
     snmp_version: str = "2c"
+    enable_active_scan: bool = True
+    enable_passive_scan: bool = True
+    enable_snmp_scan: bool = True
+
+    @model_validator(mode="after")
+    def _auto_detect_subnet(self):
+        if not self.scan_default_range.strip():
+            self.scan_default_range = _detect_local_subnet()
+        return self
 
     # SSH / Device Config
     ssh_username: str = "admin"
@@ -38,7 +64,7 @@ class Settings(BaseSettings):
     agent_mode: str = "alert"
 
     class Config:
-        env_file = ".env"
+        env_file = ("../.env", ".env")
         env_file_encoding = "utf-8"
         extra = "ignore"
 

--- a/network-topology-mapper/backend/app/db/sqlite_db.py
+++ b/network-topology-mapper/backend/app/db/sqlite_db.py
@@ -188,6 +188,11 @@ class SQLiteDB:
             result.append(d)
         return result
 
+    def clear_scans(self) -> None:
+        cursor = self._conn.cursor()
+        cursor.execute("DELETE FROM scans")
+        self._conn.commit()
+
     # Alert operations
     def create_alert(self, alert: dict) -> dict:
         cursor = self._conn.cursor()

--- a/network-topology-mapper/backend/app/routers/scans.py
+++ b/network-topology-mapper/backend/app/routers/scans.py
@@ -30,6 +30,12 @@ def list_scans(limit: int = 50):
     return {"scans": scans}
 
 
+@router.post("/scans/clear")
+def clear_scans():
+    sqlite_db.clear_scans()
+    return {"status": "ok", "message": "Scan history cleared."}
+
+
 @router.get("/scans/{scan_id}")
 def get_scan(scan_id: str):
     scan = sqlite_db.get_scan(scan_id)

--- a/network-topology-mapper/backend/app/services/scanner/active_scanner.py
+++ b/network-topology-mapper/backend/app/services/scanner/active_scanner.py
@@ -1,130 +1,67 @@
+import ipaddress
 import logging
+import platform
+import re
 import shutil
 import subprocess
 import uuid
 import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+IS_WINDOWS = platform.system().lower() == "windows"
+
 
 class ActiveScanner:
-    """Calls nmap directly via subprocess to avoid python-nmap Windows bugs."""
+    """Network scanner: ping sweep + ARP for discovery, nmap for port details."""
 
     def __init__(self):
         self._nmap_path: Optional[str] = shutil.which("nmap")
         if not self._nmap_path:
-            logger.warning("nmap binary not found in PATH. Active scanning unavailable.")
+            logger.warning("nmap binary not found in PATH. Port scanning unavailable.")
         else:
             logger.info("nmap found at: %s", self._nmap_path)
 
     @property
     def available(self) -> bool:
-        return self._nmap_path is not None
+        return True
 
     def scan_network(self, target: str = "192.168.0.0/24",
                      intensity: str = "normal",
                      callback=None) -> list[dict]:
-        if not self._nmap_path:
-            logger.warning("Nmap unavailable, returning empty results")
-            return []
+        # Phase A: Ping sweep + ARP table for host discovery
+        self._ping_sweep(target)
+        discovered = self._read_arp_table(target)
+        logger.info("Host discovery found %d devices", len(discovered))
 
-        # --unprivileged: skip raw sockets (avoids Windows assertion crash in python-nmap)
-        # -PS: TCP connect ping for host discovery (works without admin)
-        # --host-timeout 1500ms: skip hosts that don't respond quickly (dead IPs timeout fast)
-        args = {
-            "light": "--unprivileged -sn -PS21,22,80,139,443,445,3389,8080 --host-timeout 1500ms -T4",
-            "normal": "--unprivileged -sT -sV -PS21,22,80,139,443,445,3389,8080 --top-ports 100 --host-timeout 10s -T4 --max-retries 1",
-            "deep": "--unprivileged -sT -sV -sC -PS21,22,80,139,443,445,3389,8080 --top-ports 1000 --host-timeout 30s -T4",
-        }.get(intensity, "--unprivileged -sT -sV -PS21,22,80,443,445,3389 --top-ports 100 --host-timeout 10s -T4 --max-retries 1")
+        # Phase B: nmap port scan on discovered hosts for service details
+        nmap_results: dict[str, dict] = {}
+        if self._nmap_path and discovered:
+            nmap_results = self._nmap_port_scan(
+                [d["ip"] for d in discovered], intensity,
+            )
 
-        cmd = [self._nmap_path, "-oX", "-"] + args.split() + [target]
-        logger.info("Running nmap command: %s", " ".join(cmd))
-
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
-
-            if result.returncode != 0:
-                logger.error("Nmap failed with code %d: %s", result.returncode, result.stderr)
-                return []
-
-            root = ET.fromstring(result.stdout)
-
-        except subprocess.TimeoutExpired:
-            logger.error("Nmap scan timed out")
-            return []
-        except ET.ParseError as e:
-            logger.error("Failed to parse nmap XML output: %s", e)
-            return []
-        except Exception as e:
-            logger.error("Nmap scan failed: %s", e)
-            return []
-
+        # Merge discovery + port scan results
         devices = []
-        for host_el in root.findall("host"):
-            status_el = host_el.find("status")
-            if status_el is None or status_el.get("state") != "up":
-                continue
+        for disc in discovered:
+            ip = disc["ip"]
+            nmap_info = nmap_results.get(ip, {})
 
-            # IP and MAC addresses
-            ip = ""
-            mac = ""
-            for addr_el in host_el.findall("address"):
-                if addr_el.get("addrtype") == "ipv4":
-                    ip = addr_el.get("addr", "")
-                elif addr_el.get("addrtype") == "mac":
-                    mac = addr_el.get("addr", "")
-
-            if not ip:
-                continue
-
-            # Vendor from MAC address element
-            vendor = ""
-            for addr_el in host_el.findall("address"):
-                if addr_el.get("addrtype") == "mac" and addr_el.get("vendor"):
-                    vendor = addr_el.get("vendor", "")
-
-            # Hostname
-            hostname = ""
-            hostnames_el = host_el.find("hostnames")
-            if hostnames_el is not None:
-                for hn_el in hostnames_el.findall("hostname"):
-                    name = hn_el.get("name", "")
-                    if name:
-                        hostname = name
-                        break
-
-            # Ports and services
-            open_ports = []
-            services = []
-            ports_el = host_el.find("ports")
-            if ports_el is not None:
-                for port_el in ports_el.findall("port"):
-                    state_el = port_el.find("state")
-                    if state_el is not None and state_el.get("state") == "open":
-                        port_num = int(port_el.get("portid", "0"))
-                        open_ports.append(port_num)
-                        svc_el = port_el.find("service")
-                        if svc_el is not None:
-                            svc_name = svc_el.get("name", "")
-                            if svc_name:
-                                services.append(svc_name)
-
-            # OS detection
-            os_match = ""
-            os_el = host_el.find("os")
-            if os_el is not None:
-                osmatch_el = os_el.find("osmatch")
-                if osmatch_el is not None:
-                    os_match = osmatch_el.get("name", "")
+            open_ports = nmap_info.get("open_ports", [])
+            services = nmap_info.get("services", [])
+            vendor = nmap_info.get("vendor", "")
+            hostname = nmap_info.get("hostname", "")
+            os_match = nmap_info.get("os", "")
 
             device_type = self._guess_device_type(open_ports, services, vendor, os_match)
 
             device = {
                 "id": str(uuid.uuid4()),
                 "ip": ip,
-                "mac": mac,
+                "mac": disc.get("mac", ""),
                 "hostname": hostname or ip,
                 "device_type": device_type,
                 "vendor": vendor,
@@ -145,6 +82,161 @@ class ActiveScanner:
         logger.info("Active scan complete: %d devices found", len(devices))
         return devices
 
+    # ------------------------------------------------------------------
+    # Host discovery: ping sweep + ARP table
+    # ------------------------------------------------------------------
+    def _ping_sweep(self, target: str) -> None:
+        """Ping all IPs in subnet to populate the OS ARP table."""
+        try:
+            network = ipaddress.ip_network(target, strict=False)
+        except ValueError:
+            return
+
+        hosts = list(network.hosts())
+        logger.info("Ping sweep: %d hosts in %s", len(hosts), target)
+
+        ping_flag = "-n" if IS_WINDOWS else "-c"
+        timeout_flag = "-w" if IS_WINDOWS else "-W"
+        timeout_val = "500" if IS_WINDOWS else "1"
+
+        def ping_one(ip: str):
+            try:
+                subprocess.run(
+                    ["ping", ping_flag, "1", timeout_flag, timeout_val, ip],
+                    capture_output=True, timeout=3,
+                )
+            except Exception:
+                pass
+
+        with ThreadPoolExecutor(max_workers=50) as pool:
+            list(pool.map(lambda ip: ping_one(str(ip)), hosts))
+
+        logger.info("Ping sweep complete")
+
+    def _read_arp_table(self, target: str) -> list[dict]:
+        """Read ARP table and return devices within the target subnet."""
+        try:
+            result = subprocess.run(
+                ["arp", "-a"], capture_output=True, text=True, timeout=10,
+            )
+        except Exception as e:
+            logger.error("Failed to read ARP table: %s", e)
+            return []
+
+        try:
+            network = ipaddress.ip_network(target, strict=False)
+        except ValueError:
+            network = None
+
+        devices = []
+        for line in result.stdout.splitlines():
+            # Windows: "  192.168.1.1          dc-45-46-63-3f-58     dynamic"
+            win_match = re.match(
+                r"\s+([\d.]+)\s+"
+                r"([\da-fA-F]{2}[:-][\da-fA-F]{2}[:-][\da-fA-F]{2}[:-]"
+                r"[\da-fA-F]{2}[:-][\da-fA-F]{2}[:-][\da-fA-F]{2})\s+(\w+)",
+                line,
+            )
+            if win_match:
+                ip = win_match.group(1)
+                mac = win_match.group(2).upper().replace("-", ":")
+                entry_type = win_match.group(3).lower()
+                if entry_type == "static":
+                    continue
+                if mac.startswith("FF:FF:FF") or mac.startswith("01:00:5E"):
+                    continue
+                if network and ipaddress.ip_address(ip) not in network:
+                    continue
+                devices.append({"ip": ip, "mac": mac})
+
+        logger.info("ARP table: %d devices in %s", len(devices), target)
+        return devices
+
+    # ------------------------------------------------------------------
+    # Port scanning (unprivileged, runs on already-discovered hosts)
+    # ------------------------------------------------------------------
+    def _nmap_port_scan(self, ips: list[str], intensity: str) -> dict[str, dict]:
+        """Run nmap port scan on specific IPs. Returns dict keyed by IP."""
+        args = {
+            "light": "--unprivileged -sT --top-ports 20 --host-timeout 5s -T4",
+            "normal": "--unprivileged -sT -sV --top-ports 100 --host-timeout 10s -T4 --max-retries 1",
+            "deep": "--unprivileged -sT -sV -sC --top-ports 1000 --host-timeout 30s -T4",
+        }.get(intensity, "--unprivileged -sT -sV --top-ports 100 --host-timeout 10s -T4 --max-retries 1")
+
+        cmd = [self._nmap_path, "-oX", "-"] + args.split() + ips
+        logger.info("Running nmap port scan on %d hosts", len(ips))
+
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+            if result.returncode != 0:
+                logger.error("Nmap port scan failed: %s", result.stderr)
+                return {}
+            root = ET.fromstring(result.stdout)
+        except subprocess.TimeoutExpired:
+            logger.error("Nmap port scan timed out")
+            return {}
+        except ET.ParseError as e:
+            logger.error("Failed to parse nmap XML: %s", e)
+            return {}
+        except Exception as e:
+            logger.error("Nmap port scan failed: %s", e)
+            return {}
+
+        results = {}
+        for host_el in root.findall("host"):
+            ip = vendor = ""
+            for addr_el in host_el.findall("address"):
+                if addr_el.get("addrtype") == "ipv4":
+                    ip = addr_el.get("addr", "")
+                elif addr_el.get("addrtype") == "mac" and addr_el.get("vendor"):
+                    vendor = addr_el.get("vendor", "")
+            if not ip:
+                continue
+
+            hostname = ""
+            hostnames_el = host_el.find("hostnames")
+            if hostnames_el is not None:
+                for hn_el in hostnames_el.findall("hostname"):
+                    name = hn_el.get("name", "")
+                    if name:
+                        hostname = name
+                        break
+
+            open_ports = []
+            services = []
+            ports_el = host_el.find("ports")
+            if ports_el is not None:
+                for port_el in ports_el.findall("port"):
+                    state_el = port_el.find("state")
+                    if state_el is not None and state_el.get("state") == "open":
+                        port_num = int(port_el.get("portid", "0"))
+                        open_ports.append(port_num)
+                        svc_el = port_el.find("service")
+                        if svc_el is not None:
+                            svc_name = svc_el.get("name", "")
+                            if svc_name:
+                                services.append(svc_name)
+
+            os_match = ""
+            os_el = host_el.find("os")
+            if os_el is not None:
+                osmatch_el = os_el.find("osmatch")
+                if osmatch_el is not None:
+                    os_match = osmatch_el.get("name", "")
+
+            results[ip] = {
+                "hostname": hostname,
+                "vendor": vendor,
+                "os": os_match,
+                "open_ports": open_ports,
+                "services": services,
+            }
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Device type heuristics
+    # ------------------------------------------------------------------
     def _guess_device_type(self, ports: list[int], services: list[str],
                            vendor: str, os_info: str) -> str:
         vendor_lower = vendor.lower()

--- a/network-topology-mapper/frontend/src/components/panels/ScanStatus.tsx
+++ b/network-topology-mapper/frontend/src/components/panels/ScanStatus.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Play, Square, RefreshCw, Clock, ChevronDown, ChevronUp, Trash2, Terminal } from 'lucide-react';
-import { fetchScans, triggerScan, cancelScan, fetchSettings, clearTopology } from '../../lib/api';
+import { fetchScans, triggerScan, cancelScan, fetchSettings, clearTopology, clearScans } from '../../lib/api';
 import { formatTimeAgo } from '../../lib/graph-utils';
 import type { Scan, ScanProgress } from '../../types/topology';
 
@@ -75,6 +75,15 @@ export default function ScanStatus() {
       window.location.reload();
     } catch (err) {
       console.error('Failed to clear database:', err);
+    }
+  };
+
+  const handleClearScans = async () => {
+    try {
+      await clearScans();
+      setScans([]);
+    } catch (err) {
+      console.error('Failed to clear scans:', err);
     }
   };
 
@@ -259,9 +268,20 @@ export default function ScanStatus() {
         <div className="bg-nd-surface rounded-nd-card p-5 border border-nd-border">
           <div className="flex items-center justify-between mb-3">
             <span className="font-mono text-label uppercase tracking-[0.08em] text-nd-text-secondary">Recent Scans</span>
-            <button onClick={loadScans} className="text-nd-text-disabled hover:text-nd-text-primary transition-colors">
-              <RefreshCw size={14} strokeWidth={1.5} />
-            </button>
+            <div className="flex items-center gap-2">
+              {scans.length > 0 && (
+                <button
+                  onClick={handleClearScans}
+                  className="flex items-center gap-1 font-mono text-label uppercase tracking-[0.06em] text-nd-text-disabled hover:text-nd-accent transition-colors"
+                >
+                  <Trash2 size={12} strokeWidth={1.5} />
+                  Clear
+                </button>
+              )}
+              <button onClick={loadScans} className="text-nd-text-disabled hover:text-nd-text-primary transition-colors">
+                <RefreshCw size={14} strokeWidth={1.5} />
+              </button>
+            </div>
           </div>
 
           {loading && <div className="font-mono text-caption text-nd-text-disabled">[LOADING...]</div>}

--- a/network-topology-mapper/frontend/src/lib/api.ts
+++ b/network-topology-mapper/frontend/src/lib/api.ts
@@ -37,6 +37,9 @@ export const triggerScan = (type: string = 'full', target: string = '192.168.0.0
     body: JSON.stringify({ type, target, intensity }),
   });
 
+export const clearScans = () =>
+  request<any>('/scans/clear', { method: 'POST' });
+
 export const fetchScans = () => request<any>('/scans');
 
 export const fetchScan = (id: string) => request<any>(`/scans/${id}`);


### PR DESCRIPTION
## Summary

Closes #20

- Replace nmap `--unprivileged` host discovery (found 1/19 devices on home LAN) with **ping sweep + ARP table** (finds all devices in ~3s, no admin required)
- nmap still used for port scanning on discovered hosts
- Auto-detect local subnet instead of hardcoded `192.168.0.0/16`
- Add missing `enable_active_scan`/`enable_passive_scan`/`enable_snmp_scan` settings that caused `AttributeError` on scan
- Fix `.env` file not loading (wrong relative path from backend CWD)
- Add clear scan history endpoint (`POST /api/scans/clear`) and UI button

## Test plan

- [ ] Start backend + frontend bare-metal
- [ ] Verify detected network shows correct local subnet (e.g. `192.168.1.0/24`)
- [ ] Run a scan — should find all LAN devices via ping+ARP, not just those with open TCP ports
- [ ] Verify clear scans button removes scan history
- [ ] Verify clear devices button still works independently