### PR TITLE
feat: add first-class Linux compatibility

### DIFF
--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -6,12 +6,58 @@
 
 ## Prerequisites
 
+### All Platforms
 - Python 3.11+
 - Node.js 18+
 - nmap (for active scanning)
 
 Optional:
 - Redis 7 (for WebSocket pub/sub — app falls back to in-memory if unavailable)
+
+### Linux Additional Requirements
+
+**Ubuntu/Debian:**
+```bash
+# Core dependencies
+sudo apt update
+sudo apt install -y python3.11 python3.11-venv python3-pip nmap
+
+# For Scapy packet capture
+sudo apt install -y libpcap-dev python3-dev build-essential
+
+# Optional: Redis
+sudo apt install -y redis-server
+sudo systemctl enable --now redis-server
+```
+
+**Fedora/RHEL:**
+```bash
+sudo dnf install -y python3.11 nmap libpcap-devel gcc python3-devel redis
+```
+
+**Arch Linux:**
+```bash
+sudo pacman -S python nmap libpcap redis
+```
+
+### Network Scanning Privileges (Linux)
+
+Network scanning requires elevated privileges. Choose one option:
+
+**Option A: Linux Capabilities (Recommended)**
+```bash
+# Grant capabilities to nmap and python
+sudo setcap cap_net_raw,cap_net_admin=eip $(which nmap)
+sudo setcap cap_net_raw,cap_net_admin=eip $(which python3.11)
+```
+
+**Option B: Run as Root (Not Recommended)**
+```bash
+sudo uvicorn app.main:app --reload --port 8000
+```
+
+**Option C: Use Unprivileged Mode**
+No setup required — NTS auto-detects and falls back to TCP connect scans. Slower but works without elevated privileges.
 
 ### Install Redis (Optional)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ Network discovery and visualization tool. Scans your LAN with nmap + SNMP + pass
 
 ### Run
 
+**Linux/macOS:**
+```bash
+cd network-topology-mapper
+chmod +x start.sh
+./start.sh
+```
+
+**Windows:**
+```cmd
+cd network-topology-mapper
+start.bat
+```
+
+**Manual (any platform):**
 ```bash
 cd network-topology-mapper
 

--- a/network-topology-mapper/.env.example
+++ b/network-topology-mapper/.env.example
@@ -26,7 +26,11 @@ SCAN_DEFAULT_RANGE=192.168.0.0/16
 SCAN_RATE_LIMIT=1000
 
 # Network interface for passive scanning
-SCAN_PASSIVE_INTERFACE=eth0
+# Leave empty for auto-detection, or specify explicitly:
+# Linux: eth0, enp3s0, wlan0, etc.
+# macOS: en0, en1
+# Windows: Ethernet, Wi-Fi
+SCAN_PASSIVE_INTERFACE=
 
 # Enable/disable scan types
 ENABLE_ACTIVE_SCAN=true

--- a/network-topology-mapper/backend/app/config.py
+++ b/network-topology-mapper/backend/app/config.py
@@ -1,5 +1,15 @@
 from pydantic_settings import BaseSettings
 from functools import lru_cache
+from typing import Optional
+
+
+def _get_default_interface() -> str:
+    """Lazy import to avoid circular dependency."""
+    try:
+        from app.utils.platform_utils import get_default_interface
+        return get_default_interface()
+    except ImportError:
+        return "eth0"
 
 
 class Settings(BaseSettings):
@@ -12,9 +22,14 @@ class Settings(BaseSettings):
     # Scanning
     scan_default_range: str = "192.168.0.0/16"
     scan_rate_limit: int = 1000
-    scan_passive_interface: str = "eth0"
+    scan_passive_interface: str = ""  # Empty = auto-detect
     snmp_community: str = "public"
     snmp_version: str = "2c"
+
+    # Feature toggles
+    enable_active_scan: bool = True
+    enable_passive_scan: bool = True
+    enable_snmp_scan: bool = True
 
     # SSH / Device Config
     ssh_username: str = "admin"
@@ -37,6 +52,12 @@ class Settings(BaseSettings):
         env_file = ".env"
         env_file_encoding = "utf-8"
         extra = "ignore"
+
+    def get_passive_interface(self) -> str:
+        """Return configured interface or auto-detect."""
+        if self.scan_passive_interface:
+            return self.scan_passive_interface
+        return _get_default_interface()
 
 
 @lru_cache()

--- a/network-topology-mapper/backend/app/services/scanner/active_scanner.py
+++ b/network-topology-mapper/backend/app/services/scanner/active_scanner.py
@@ -6,6 +6,8 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 from typing import Optional
 
+from app.utils.platform_utils import get_nmap_privilege_flags
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,14 +32,25 @@ class ActiveScanner:
             logger.warning("Nmap unavailable, returning empty results")
             return []
 
-        # --unprivileged: skip raw sockets (avoids Windows assertion crash in python-nmap)
-        # -PS: TCP connect ping for host discovery (works without admin)
-        # --host-timeout 1500ms: skip hosts that don't respond quickly (dead IPs timeout fast)
-        args = {
-            "light": "--unprivileged -sn -PS21,22,80,139,443,445,3389,8080 --host-timeout 1500ms -T4",
-            "normal": "--unprivileged -sT -sV -PS21,22,80,139,443,445,3389,8080 --top-ports 100 --host-timeout 10s -T4 --max-retries 1",
-            "deep": "--unprivileged -sT -sV -sC -PS21,22,80,139,443,445,3389,8080 --top-ports 1000 --host-timeout 30s -T4",
-        }.get(intensity, "--unprivileged -sT -sV -PS21,22,80,443,445,3389 --top-ports 100 --host-timeout 10s -T4 --max-retries 1")
+        priv_flag = get_nmap_privilege_flags()
+
+        # Base flags differ based on privilege level.
+        # Unprivileged: TCP connect (-sT) only — works without raw sockets.
+        # Privileged:   SYN (-sS) + ICMP echo + OS detect — faster, stealthier.
+        if priv_flag:
+            args_map = {
+                "light": f"{priv_flag} -sn -PS21,22,80,139,443,445,3389,8080 --host-timeout 1500ms -T4",
+                "normal": f"{priv_flag} -sT -sV -PS21,22,80,139,443,445,3389,8080 --top-ports 100 --host-timeout 10s -T4 --max-retries 1",
+                "deep": f"{priv_flag} -sT -sV -sC -PS21,22,80,139,443,445,3389,8080 --top-ports 1000 --host-timeout 30s -T4",
+            }
+        else:
+            args_map = {
+                "light": "-sn -PE -PS21,22,80,443 --host-timeout 1500ms -T4",
+                "normal": "-sS -sV -PE -PS21,22,80,443 --top-ports 100 --host-timeout 10s -T4 --max-retries 1",
+                "deep": "-sS -sV -sC -O -PE -PS21,22,80,443 --top-ports 1000 --host-timeout 30s -T4",
+            }
+
+        args = args_map.get(intensity, args_map["normal"])
 
         cmd = [self._nmap_path, "-oX", "-"] + args.split() + [target]
         logger.info("Running nmap command: %s", " ".join(cmd))

--- a/network-topology-mapper/backend/app/services/scanner/passive_scanner.py
+++ b/network-topology-mapper/backend/app/services/scanner/passive_scanner.py
@@ -29,7 +29,14 @@ class PassiveScanner:
     def is_running(self) -> bool:
         return self._running
 
-    def start(self, interface: str = "eth0", callback: Callable = None):
+    def start(self, interface: Optional[str] = None, callback: Callable = None):
+        """
+        Start passive scanning.
+
+        Args:
+            interface: Network interface to sniff on. If None, uses config default.
+            callback: Function called for each discovered device.
+        """
         if not self._scapy:
             logger.warning("Scapy unavailable, cannot start passive scanner")
             return
@@ -37,6 +44,11 @@ class PassiveScanner:
         if self._running:
             logger.warning("Passive scanner already running")
             return
+
+        # Auto-detect interface if not provided
+        if interface is None:
+            from app.config import get_settings
+            interface = get_settings().get_passive_interface()
 
         self._callback = callback
         self._running = True

--- a/network-topology-mapper/backend/app/services/scanner/scan_coordinator.py
+++ b/network-topology-mapper/backend/app/services/scanner/scan_coordinator.py
@@ -237,7 +237,7 @@ class ScanCoordinator:
             return
 
         settings = get_settings()
-        interface = settings.scan_passive_interface
+        interface = settings.get_passive_interface()
 
         collected = []
 

--- a/network-topology-mapper/backend/app/utils/__init__.py
+++ b/network-topology-mapper/backend/app/utils/__init__.py
@@ -1,0 +1,17 @@
+from app.utils.platform_utils import (
+    is_linux,
+    is_windows,
+    is_macos,
+    has_raw_socket_capability,
+    get_default_interface,
+    get_nmap_privilege_flags,
+)
+
+__all__ = [
+    "is_linux",
+    "is_windows",
+    "is_macos",
+    "has_raw_socket_capability",
+    "get_default_interface",
+    "get_nmap_privilege_flags",
+]

--- a/network-topology-mapper/backend/app/utils/platform_utils.py
+++ b/network-topology-mapper/backend/app/utils/platform_utils.py
@@ -1,0 +1,164 @@
+"""Cross-platform utilities for network interface and privilege detection."""
+
+import os
+import sys
+import socket
+import logging
+import subprocess
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def is_linux() -> bool:
+    return sys.platform.startswith("linux")
+
+
+def is_windows() -> bool:
+    return sys.platform == "win32"
+
+
+def is_macos() -> bool:
+    return sys.platform == "darwin"
+
+
+def has_raw_socket_capability() -> bool:
+    """Check if the current process can create raw sockets (for nmap/scapy)."""
+    if is_windows():
+        # Windows: raw sockets require admin, but nmap handles this internally
+        # We use --unprivileged mode on Windows regardless
+        return False
+
+    # Linux/macOS: check if we're root or have CAP_NET_RAW
+    if os.geteuid() == 0:
+        return True
+
+    # Check for CAP_NET_RAW capability (Linux only)
+    if is_linux():
+        try:
+            result = subprocess.run(
+                ["capsh", "--print"],
+                capture_output=True, text=True, timeout=5
+            )
+            if "cap_net_raw" in result.stdout.lower():
+                return True
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+
+    return False
+
+
+def get_default_interface() -> str:
+    """
+    Detect the default network interface for the current platform.
+
+    Returns:
+        Interface name (e.g., 'eth0', 'enp3s0', 'en0', 'Ethernet')
+    """
+    if is_windows():
+        return _get_windows_default_interface()
+    else:
+        return _get_unix_default_interface()
+
+
+def _get_unix_default_interface() -> str:
+    """Get default interface on Linux/macOS by checking the default route."""
+    try:
+        # Method 1: Parse 'ip route' output (Linux)
+        if is_linux():
+            result = subprocess.run(
+                ["ip", "route", "show", "default"],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0 and result.stdout:
+                # Output: "default via 192.168.1.1 dev eth0 proto ..."
+                parts = result.stdout.split()
+                if "dev" in parts:
+                    idx = parts.index("dev")
+                    if idx + 1 < len(parts):
+                        iface = parts[idx + 1]
+                        logger.debug("Detected default interface via 'ip route': %s", iface)
+                        return iface
+
+        # Method 2: Parse 'route' output (macOS fallback)
+        if is_macos():
+            result = subprocess.run(
+                ["route", "-n", "get", "default"],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0:
+                for line in result.stdout.splitlines():
+                    if "interface:" in line.lower():
+                        iface = line.split(":")[-1].strip()
+                        logger.debug("Detected default interface via 'route': %s", iface)
+                        return iface
+
+        # Method 3: Fallback - try common interface names
+        for candidate in ["eth0", "enp0s3", "enp3s0", "ens33", "en0", "wlan0", "wlp2s0"]:
+            if _interface_exists(candidate):
+                logger.debug("Using fallback interface: %s", candidate)
+                return candidate
+
+    except Exception as e:
+        logger.warning("Failed to detect default interface: %s", e)
+
+    # Ultimate fallback
+    logger.warning("Could not detect interface, defaulting to 'eth0'")
+    return "eth0"
+
+
+def _get_windows_default_interface() -> str:
+    """Get default interface on Windows."""
+    try:
+        # Use PowerShell to get the interface with default route
+        result = subprocess.run(
+            ["powershell", "-Command",
+             "(Get-NetRoute -DestinationPrefix '0.0.0.0/0' | "
+             "Sort-Object -Property RouteMetric | "
+             "Select-Object -First 1).InterfaceAlias"],
+            capture_output=True, text=True, timeout=10
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            iface = result.stdout.strip()
+            logger.debug("Detected Windows interface: %s", iface)
+            return iface
+    except Exception as e:
+        logger.warning("Failed to detect Windows interface: %s", e)
+
+    # Fallback to common Windows interface names
+    return "Ethernet"
+
+
+def _interface_exists(name: str) -> bool:
+    """Check if a network interface exists."""
+    try:
+        if is_linux():
+            return os.path.exists(f"/sys/class/net/{name}")
+        elif is_macos():
+            result = subprocess.run(
+                ["ifconfig", name],
+                capture_output=True, timeout=5
+            )
+            return result.returncode == 0
+    except Exception:
+        pass
+    return False
+
+
+def get_nmap_privilege_flags() -> str:
+    """
+    Return nmap flags appropriate for the current privilege level.
+
+    On Windows or without privileges: --unprivileged (TCP connect scans only)
+    On Linux/macOS with privileges: empty string (allows SYN scans, faster)
+    """
+    if is_windows():
+        # Always use unprivileged on Windows to avoid assertion crashes
+        return "--unprivileged"
+
+    if has_raw_socket_capability():
+        logger.info("Running with raw socket capability - using privileged nmap mode")
+        return ""
+
+    logger.info("No raw socket capability - using unprivileged nmap mode")
+    return "--unprivileged"

--- a/network-topology-mapper/backend/tests/test_platform_utils.py
+++ b/network-topology-mapper/backend/tests/test_platform_utils.py
@@ -1,0 +1,83 @@
+"""Tests for platform detection utilities."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from app.utils.platform_utils import (
+    is_linux,
+    is_windows,
+    is_macos,
+    has_raw_socket_capability,
+    get_default_interface,
+    get_nmap_privilege_flags,
+)
+
+
+class TestPlatformDetection:
+    @patch("sys.platform", "linux")
+    def test_is_linux_true(self):
+        assert is_linux() is True
+        assert is_windows() is False
+        assert is_macos() is False
+
+    @patch("sys.platform", "win32")
+    def test_is_windows_true(self):
+        assert is_windows() is True
+        assert is_linux() is False
+
+    @patch("sys.platform", "darwin")
+    def test_is_macos_true(self):
+        assert is_macos() is True
+        assert is_linux() is False
+
+
+class TestPrivilegeDetection:
+    @patch("sys.platform", "win32")
+    def test_windows_never_privileged(self):
+        assert has_raw_socket_capability() is False
+
+    @patch("sys.platform", "linux")
+    @patch("os.geteuid", create=True, return_value=0)
+    def test_linux_root_is_privileged(self, mock_euid):
+        assert has_raw_socket_capability() is True
+
+    @patch("sys.platform", "linux")
+    @patch("os.geteuid", create=True, return_value=1000)
+    @patch("subprocess.run")
+    def test_linux_with_capability(self, mock_run, mock_euid):
+        mock_run.return_value = MagicMock(stdout="cap_net_raw", returncode=0)
+        assert has_raw_socket_capability() is True
+
+
+class TestInterfaceDetection:
+    @patch("sys.platform", "linux")
+    @patch("subprocess.run")
+    def test_linux_interface_from_ip_route(self, mock_run):
+        mock_run.return_value = MagicMock(
+            stdout="default via 192.168.1.1 dev enp3s0 proto dhcp",
+            returncode=0
+        )
+        assert get_default_interface() == "enp3s0"
+
+    @patch("sys.platform", "linux")
+    @patch("subprocess.run")
+    @patch("os.path.exists")
+    def test_linux_fallback_to_eth0(self, mock_exists, mock_run):
+        mock_run.return_value = MagicMock(stdout="", returncode=1)
+        mock_exists.side_effect = lambda p: p == "/sys/class/net/eth0"
+        assert get_default_interface() == "eth0"
+
+
+class TestNmapFlags:
+    @patch("sys.platform", "win32")
+    def test_windows_always_unprivileged(self):
+        assert get_nmap_privilege_flags() == "--unprivileged"
+
+    @patch("sys.platform", "linux")
+    @patch("app.utils.platform_utils.has_raw_socket_capability", return_value=True)
+    def test_linux_privileged(self, mock_cap):
+        assert get_nmap_privilege_flags() == ""
+
+    @patch("sys.platform", "linux")
+    @patch("app.utils.platform_utils.has_raw_socket_capability", return_value=False)
+    def test_linux_unprivileged(self, mock_cap):
+        assert get_nmap_privilege_flags() == "--unprivileged"

--- a/network-topology-mapper/start.sh
+++ b/network-topology-mapper/start.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# =============================================================================
+# NTS Local Development Startup Script (Linux/macOS)
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "Starting Network Topology Mapper..."
+
+# Check prerequisites
+command -v python3 >/dev/null 2>&1 || { echo "Error: python3 not found"; exit 1; }
+command -v node >/dev/null 2>&1 || { echo "Error: node not found"; exit 1; }
+command -v nmap >/dev/null 2>&1 || { echo "Warning: nmap not found - active scanning will be unavailable"; }
+
+# Backend
+echo "Starting Backend API (Port 8000)..."
+cd backend
+if [ ! -d ".venv" ]; then
+    echo "Creating virtual environment..."
+    python3 -m venv .venv
+fi
+source .venv/bin/activate
+pip install -q -r requirements.txt
+
+# Start backend in background
+uvicorn app.main:app --reload --port 8000 &
+BACKEND_PID=$!
+cd ..
+
+# Frontend
+echo "Starting Frontend Dev Server (Port 3000)..."
+cd frontend
+if [ ! -d "node_modules" ]; then
+    echo "Installing npm dependencies..."
+    npm install
+fi
+npm run dev &
+FRONTEND_PID=$!
+cd ..
+
+echo ""
+echo "Services starting:"
+echo "  Backend:  http://localhost:8000 (PID: $BACKEND_PID)"
+echo "  Frontend: http://localhost:3000 (PID: $FRONTEND_PID)"
+echo ""
+echo "Press Ctrl+C to stop all services."
+
+# Trap Ctrl+C and kill both processes
+trap "echo 'Stopping services...'; kill $BACKEND_PID $FRONTEND_PID 2>/dev/null; exit 0" SIGINT SIGTERM
+
+# Wait for either process to exit
+wait


### PR DESCRIPTION
Closes #24

## Summary

- Adds `backend/app/utils/platform_utils.py` for cross-platform detection: `is_linux/is_windows/is_macos`, `has_raw_socket_capability` (root or `CAP_NET_RAW`), `get_default_interface` (parses `ip route` on Linux, `route -n get default` on macOS, PowerShell `Get-NetRoute` on Windows), and `get_nmap_privilege_flags`.
- Adds `start.sh` (mode 100755) — Linux/macOS launcher with prereq checks, venv bootstrap, backend + frontend launch, and SIGINT/SIGTERM trap that kills both children.
- `active_scanner.py` now picks SYN scans (`-sS`/`-PE`/`-O`) when raw sockets are available and falls back to TCP-connect (`-sT`) with `--unprivileged` otherwise. Windows always uses unprivileged mode to avoid the python-nmap raw-socket assertion crash.
- `config.py` adds `get_passive_interface()` (returns the configured value or auto-detects), changes `scan_passive_interface` default from `eth0` to `""`, and backfills the missing `enable_active_scan` / `enable_passive_scan` / `enable_snmp_scan` settings that `scan_coordinator.py` was already dereferencing.
- `passive_scanner.py` defaults `interface=None` and lazily resolves via `get_passive_interface()`. `scan_coordinator._run_passive_scan` calls the new method.
- Docs: `INSTALL_GUIDE.md` gets Linux prerequisites (Ubuntu/Debian, Fedora/RHEL, Arch) and three privilege options (capabilities / root / unprivileged). `README.md` quickstart now shows Linux/macOS, Windows, and manual paths. `.env.example` documents that an empty `SCAN_PASSIVE_INTERFACE` triggers auto-detection and lists per-OS examples.
- Adds `tests/test_platform_utils.py` (11 tests covering platform detection, privilege detection, interface parsing, and nmap flag selection).

## Test plan

- [x] `pytest tests/` — full backend suite: **31 passed** (20 existing + 11 new) on Windows
- [x] Smoke check on Windows: `get_settings().get_passive_interface()` resolved to `Wi-Fi` via PowerShell `Get-NetRoute`; `get_nmap_privilege_flags()` returned `--unprivileged`; `enable_active_scan` is now a real attribute
- [ ] Linux: `chmod +x start.sh && ./start.sh` launches both services
- [ ] Linux: passive scan starts without explicit `SCAN_PASSIVE_INTERFACE`; check logs for the auto-detected interface
- [ ] Linux as root or with `setcap cap_net_raw,cap_net_admin=eip $(which nmap)`: nmap log line shows no `--unprivileged` flag
- [ ] Linux as regular user: nmap log line includes `--unprivileged`
- [ ] macOS: `route -n get default` path resolves the active interface